### PR TITLE
优化消息处理增加会话上下文自定义参数、增加deepseek模型支持

### DIFF
--- a/agents-flex-core/src/main/java/com/agentsflex/core/llm/ChatContext.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/llm/ChatContext.java
@@ -16,10 +16,15 @@
 package com.agentsflex.core.llm;
 
 import com.agentsflex.core.llm.client.LlmClient;
+import com.agentsflex.core.message.AiMessage;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ChatContext {
     private Llm llm;
     private LlmClient client;
+    private final Map<String, Object> params = new HashMap<>();
 
     public ChatContext() {
     }
@@ -43,5 +48,22 @@ public class ChatContext {
 
     public void setClient(LlmClient client) {
         this.client = client;
+    }
+
+    public void addLastAiMessage(AiMessage aiMessageContent) {
+        addParam("lastAiMessage", aiMessageContent);
+    }
+
+    public AiMessage getLastAiMessage() {
+        return getParam("lastAiMessage");
+    }
+
+    public ChatContext addParam(String key, Object value) {
+        params.put(key, value);
+        return this;
+    }
+
+    public <T> T getParam(String key) {
+        return (T) params.get(key);
     }
 }

--- a/agents-flex-core/src/main/java/com/agentsflex/core/llm/client/BaseLlmClientListener.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/llm/client/BaseLlmClientListener.java
@@ -27,6 +27,8 @@ import com.agentsflex.core.util.StringUtil;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 
+import java.util.Objects;
+
 public class BaseLlmClientListener implements LlmClientListener {
 
     private final StreamResponseListener streamResponseListener;
@@ -63,7 +65,13 @@ public class BaseLlmClientListener implements LlmClientListener {
         try {
             JSONObject jsonObject = JSON.parseObject(response);
             lastAiMessage = messageParser.parse(jsonObject);
-            fullMessage.append(lastAiMessage.getContent());
+            String content = lastAiMessage.getContent();
+
+            // 第一个和最后一个content都为null
+            if (Objects.nonNull(content)) {
+                fullMessage.append(content);
+            }
+
             lastAiMessage.setFullContent(fullMessage.toString());
             AiMessageResponse aiMessageResponse = new AiMessageResponse(prompt, response, lastAiMessage);
             streamResponseListener.onMessage(context, aiMessageResponse);
@@ -79,7 +87,7 @@ public class BaseLlmClientListener implements LlmClientListener {
                 ((HistoriesPrompt) this.prompt).addMessage(lastAiMessage);
             }
         }
-
+        context.addLastAiMessage(lastAiMessage);
         streamResponseListener.onStop(context);
     }
 

--- a/agents-flex-llm/agents-flex-llm-deepseek/pom.xml
+++ b/agents-flex-llm/agents-flex-llm-deepseek/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.agentsflex</groupId>
+        <artifactId>agents-flex-llm</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <packaging>jar</packaging>
+    <name>agents-flex-llm-deepseek</name>
+    <artifactId>agents-flex-llm-deepseek</artifactId>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.agentsflex</groupId>
+            <artifactId>agents-flex-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.agentsflex</groupId>
+            <artifactId>agents-flex-llm-openai</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekConfig.java
+++ b/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekConfig.java
@@ -1,0 +1,28 @@
+/*
+ * @(#) DeepseekConfig Created by tony on 2025-01-17 15:26
+ * @copyright © 2018-2024 博信数科科技. All rights reserved.
+ */
+package com.agentsflex.llm.deepseek;
+
+import com.agentsflex.core.llm.LlmConfig;
+
+/**
+ * @author huangjf
+ * @version : v1.0
+ */
+public class DeepseekConfig extends LlmConfig {
+
+    private static final String DEFAULT_MODEL = "deepseek-chat";
+    private static final String DEFAULT_EMBEDDING_MODEL = "";
+    private static final String DEFAULT_ENDPOINT = "https://api.deepseek.com";
+
+    public DeepseekConfig() {
+        setEndpoint(DEFAULT_ENDPOINT);
+        setModel(DEFAULT_MODEL);
+    }
+
+    public DeepseekConfig(String model) {
+        this();
+        setModel(model);
+    }
+}

--- a/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekLLmUtil.java
+++ b/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekLLmUtil.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2023-2025, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.llm.deepseek;
+
+import com.agentsflex.core.document.Document;
+import com.agentsflex.core.llm.ChatOptions;
+import com.agentsflex.core.llm.LlmConfig;
+import com.agentsflex.core.llm.embedding.EmbeddingOptions;
+import com.agentsflex.core.message.HumanMessage;
+import com.agentsflex.core.message.Message;
+import com.agentsflex.core.parser.AiMessageParser;
+import com.agentsflex.core.parser.impl.DefaultAiMessageParser;
+import com.agentsflex.core.prompt.DefaultPromptFormat;
+import com.agentsflex.core.prompt.Prompt;
+import com.agentsflex.core.prompt.PromptFormat;
+import com.agentsflex.core.util.CollectionUtil;
+import com.agentsflex.core.util.Maps;
+import com.agentsflex.llm.openai.OpenAiLlmConfig;
+
+import java.util.List;
+
+public class DeepseekLLmUtil {
+
+    private static final PromptFormat promptFormat = new DefaultPromptFormat();
+
+    public static AiMessageParser getAiMessageParser(boolean isStream) {
+        return DefaultAiMessageParser.getChatGPTMessageParser(isStream);
+    }
+
+
+    public static String promptToEmbeddingsPayload(Document text, EmbeddingOptions options, OpenAiLlmConfig config) {
+        // https://platform.openai.com/docs/api-reference/making-requests
+        return Maps.of("model", options.getModelOrDefault(config.getDefaultEmbeddingModel()))
+            .set("encoding_format", "float")
+            .set("input", text.getContent())
+            .toJSON();
+    }
+
+
+    public static String promptToPayload(Prompt prompt, LlmConfig config, ChatOptions options, boolean withStream) {
+        List<Message> messages = prompt.toMessages();
+        HumanMessage humanMessage = (HumanMessage) CollectionUtil.lastItem(messages);
+        return Maps.of("model", config.getModel())
+            .set("messages", promptFormat.toMessagesJsonObject(messages))
+            .setIf(withStream, "stream", true)
+            .setIfNotEmpty("tools", promptFormat.toFunctionsJsonObject(humanMessage))
+            //.setIfContainsKey("tools", "tool_choice", humanMessage.getToolChoice())
+            .setIfNotNull("top_p", options.getTopP())
+            .setIfNotEmpty("stop", options.getStop())
+            .setIf(map -> !map.containsKey("tools") && options.getTemperature() > 0, "temperature", options.getTemperature())
+            .setIf(map -> !map.containsKey("tools") && options.getMaxTokens() != null, "max_tokens", options.getMaxTokens())
+            .toJSON();
+    }
+
+
+}

--- a/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekLlm.java
+++ b/agents-flex-llm/agents-flex-llm-deepseek/src/main/java/com/agentsflex/llm/deepseek/DeepseekLlm.java
@@ -1,0 +1,106 @@
+/*
+ * @(#) DeepseekLlm Created by tony on 2025-01-17 15:25
+ * @copyright © 2018-2024 博信数科科技. All rights reserved.
+ */
+package com.agentsflex.llm.deepseek;
+
+import com.agentsflex.core.document.Document;
+import com.agentsflex.core.llm.BaseLlm;
+import com.agentsflex.core.llm.ChatOptions;
+import com.agentsflex.core.llm.StreamResponseListener;
+import com.agentsflex.core.llm.client.BaseLlmClientListener;
+import com.agentsflex.core.llm.client.HttpClient;
+import com.agentsflex.core.llm.client.LlmClient;
+import com.agentsflex.core.llm.client.LlmClientListener;
+import com.agentsflex.core.llm.client.impl.SseClient;
+import com.agentsflex.core.llm.embedding.EmbeddingOptions;
+import com.agentsflex.core.llm.response.AiMessageResponse;
+import com.agentsflex.core.parser.AiMessageParser;
+import com.agentsflex.core.prompt.Prompt;
+import com.agentsflex.core.store.VectorData;
+import com.agentsflex.core.util.StringUtil;
+import com.agentsflex.llm.openai.OpenAiLLmUtil;
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * @author huangjf
+ * @version : v1.0
+ */
+public class DeepseekLlm extends BaseLlm<DeepseekConfig> {
+
+    private final Map<String, String> headers = new HashMap<>();
+    private final HttpClient httpClient = new HttpClient();
+    private final AiMessageParser aiMessageParser = OpenAiLLmUtil.getAiMessageParser(false);
+    private final AiMessageParser streamMessageParser = OpenAiLLmUtil.getAiMessageParser(true);
+
+    public DeepseekLlm(DeepseekConfig config) {
+        super(config);
+        headers.put("Content-Type", "application/json");
+        headers.put("Accept", "application/json");
+        headers.put("Authorization", "Bearer " + getConfig().getApiKey());
+    }
+
+    public static DeepseekLlm of(String apiKey) {
+        DeepseekConfig config = new DeepseekConfig();
+        config.setApiKey(apiKey);
+        return new DeepseekLlm(config);
+    }
+
+    @Override
+    public AiMessageResponse chat(Prompt prompt, ChatOptions options) {
+
+        Consumer<Map<String, String>> headersConfig = config.getHeadersConfig();
+        if (headersConfig != null) {
+            headersConfig.accept(headers);
+        }
+
+        String payload = DeepseekLLmUtil.promptToPayload(prompt, config, options, false);
+        String endpoint = config.getEndpoint();
+        String response = httpClient.post(endpoint + "/chat/completions", headers, payload);
+
+        if (config.isDebug()) {
+            System.out.println(">>>>receive payload:" + response);
+        }
+
+        if (StringUtil.noText(response)) {
+            return AiMessageResponse.error(prompt, response, "no content for response.");
+        }
+
+        JSONObject jsonObject = JSON.parseObject(response);
+        JSONObject error = jsonObject.getJSONObject("error");
+
+        AiMessageResponse messageResponse = new AiMessageResponse(prompt, response, aiMessageParser.parse(jsonObject));
+        if (error != null && !error.isEmpty()) {
+            messageResponse.setError(true);
+            messageResponse.setErrorMessage(error.getString("message"));
+            messageResponse.setErrorType(error.getString("type"));
+            messageResponse.setErrorCode(error.getString("code"));
+        }
+
+        return messageResponse;
+    }
+
+    @Override
+    public void chatStream(Prompt prompt, StreamResponseListener streamResponseListener, ChatOptions chatOptions) {
+        LlmClient llmClient = new SseClient();
+        String payload = DeepseekLLmUtil.promptToPayload(prompt, config, chatOptions, true);
+        String endpoint = config.getEndpoint();
+        LlmClientListener clientListener = new BaseLlmClientListener(this, llmClient, streamResponseListener, prompt, streamMessageParser);
+        llmClient.start(endpoint + "/chat/completions", headers, payload, clientListener, config);
+    }
+
+    @Override
+    public void chatStream(Prompt prompt, StreamResponseListener streamResponseListener) {
+        chatStream(prompt, streamResponseListener, ChatOptions.DEFAULT);
+    }
+
+    @Override
+    public VectorData embed(Document document, EmbeddingOptions embeddingOptions) {
+        return null;
+    }
+}

--- a/agents-flex-llm/pom.xml
+++ b/agents-flex-llm/pom.xml
@@ -22,6 +22,7 @@
         <module>agents-flex-llm-moonshot</module>
         <module>agents-flex-llm-coze</module>
         <module>agents-flex-llm-gitee</module>
+        <module>agents-flex-llm-deepseek</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
1、优化基础监听类BaseLlmClientListener保存流式数据逻辑，去掉第一个和最后一个其值为null的值。
2、为ChatContext增加了参数功能。以支持在消息处理和停止处理时，可以存取、自定义数据
3、仿照openai llm实现，增加支持deepseek大模型