### PR TITLE
fix(core): restore polymorphic Message deserialization in ReActAgentState.fromJSON

### DIFF
--- a/agents-flex-core/src/main/java/com/agentsflex/core/agent/react/ReActAgentState.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/agent/react/ReActAgentState.java
@@ -105,7 +105,11 @@ public class ReActAgentState implements Serializable {
     }
 
     public static ReActAgentState fromJSON(String json) {
-        return JSON.parseObject(json, ReActAgentState.class, JSONReader.Feature.SupportClassForName);
+        // toJSON() writes @type markers via JSONWriter.Feature.WriteClassName. Reading them back to
+        // restore the concrete Message subtypes (UserMessage / AiMessage ...) in messageHistory
+        // requires SupportAutoType — its counterpart. SupportClassForName only covers Class-typed
+        // fields and leaves fastjson2 trying to instantiate the abstract Message, which fails.
+        return JSON.parseObject(json, ReActAgentState.class, JSONReader.Feature.SupportAutoType);
     }
 
 

--- a/agents-flex-core/src/test/java/com/agentsflex/core/agent/react/ReActAgentStateTest.java
+++ b/agents-flex-core/src/test/java/com/agentsflex/core/agent/react/ReActAgentStateTest.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.core.agent.react;
+
+import com.agentsflex.core.message.AiMessage;
+import com.agentsflex.core.message.Message;
+import com.agentsflex.core.message.UserMessage;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * 复现并验证 GitHub issue #50：ReActAgentState 的 toJSON()/fromJSON() 往返序列化。
+ *
+ * <p>修复前，{@link ReActAgentState#fromJSON(String)} 使用 {@code SupportClassForName}，
+ * 无法解析 {@code @type} 标记，fastjson2 会尝试实例化抽象类 {@link Message} 并抛出
+ * {@code create instance error}。修复后使用 {@code SupportAutoType}，可正确还原
+ * {@link UserMessage}/{@link AiMessage} 等具体子类型。
+ *
+ * <p>本测试不依赖网络或 LLM，可离线运行。
+ */
+public class ReActAgentStateTest {
+
+    @Test
+    public void testToJsonFromJsonRoundTrip_restoresConcreteMessageSubtypes() {
+        ReActAgentState state = new ReActAgentState();
+        state.setUserQuery("今天的天气怎么样？");
+        state.setIterationCount(3);
+        state.setMaxIterations(20);
+        state.setStreamable(true);
+        state.setContinueOnActionInvokeError(true);
+
+        UserMessage userMessage = new UserMessage("我在北京市");
+        userMessage.putMetadata("type", "reActObservation");
+
+        AiMessage aiMessage = new AiMessage();
+        aiMessage.setContent("Final Answer: 北京今天晴。");
+        aiMessage.putMetadata("type", "reActFinalAnswer");
+
+        List<Message> history = new ArrayList<>();
+        history.add(userMessage);
+        history.add(aiMessage);
+        state.setMessageHistory(history);
+
+        // 序列化 -> 反序列化（修复前此处会抛出 JSONException: create instance error）
+        String json = state.toJSON();
+        ReActAgentState restored = ReActAgentState.fromJSON(json);
+
+        assertNotNull(restored);
+
+        // 标量字段往返保持
+        assertEquals("今天的天气怎么样？", restored.getUserQuery());
+        assertEquals(3, restored.getIterationCount());
+        assertEquals(20, restored.getMaxIterations());
+        assertTrue(restored.isStreamable());
+        assertTrue(restored.isContinueOnActionInvokeError());
+
+        // 关键：messageHistory 中的具体子类型被正确还原
+        List<Message> restoredHistory = restored.getMessageHistory();
+        assertNotNull(restoredHistory);
+        assertEquals(2, restoredHistory.size());
+
+        assertTrue("第一个消息应还原为 UserMessage", restoredHistory.get(0) instanceof UserMessage);
+        assertTrue("第二个消息应还原为 AiMessage", restoredHistory.get(1) instanceof AiMessage);
+
+        UserMessage restoredUser = (UserMessage) restoredHistory.get(0);
+        assertEquals("我在北京市", restoredUser.getContent());
+        assertEquals("reActObservation", restoredUser.getMetadata("type"));
+
+        AiMessage restoredAi = (AiMessage) restoredHistory.get(1);
+        assertEquals("Final Answer: 北京今天晴。", restoredAi.getContent());
+        assertEquals("reActFinalAnswer", restoredAi.getMetadata("type"));
+    }
+
+    @Test
+    public void testFromJson_emptyHistory_roundTrips() {
+        ReActAgentState state = new ReActAgentState();
+        state.setUserQuery("hello");
+
+        ReActAgentState restored = ReActAgentState.fromJSON(state.toJSON());
+
+        assertNotNull(restored);
+        assertEquals("hello", restored.getUserQuery());
+        assertNull(restored.getMessageHistory());
+    }
+}


### PR DESCRIPTION
## 问题 / Problem

修复 #50：`ReActAgentState.fromJSON()` 反序列化失败，抛出：

```
com.alibaba.fastjson2.JSONException: create instance error, class com.agentsflex.core.message.Message
```

`toJSON()` 通过 `JSONWriter.Feature.WriteClassName` 正确写入了 `@type` 标记，但 `fromJSON()` 使用的是 `JSONReader.Feature.SupportClassForName`。该特性只对“类型为 `Class` 的字段”启用 `Class.forName`，并不会读取 `@type`；于是 fastjson2 会对 `messageHistory` 中的每个元素尝试实例化**抽象类** `Message`，从而抛出上述异常。这使得 ReAct 的「暂停 → 向用户提问 → 恢复」状态持久化流程不可用。

## 修复 / Fix

把 `fromJSON()` 的 reader feature 从 `SupportClassForName` 改为 `SupportAutoType`（即 `WriteClassName` 的正确搭配），即可按 `@type` 正确还原 `UserMessage` / `AiMessage` 等具体子类型。序列化端无需改动。

```java
// before
return JSON.parseObject(json, ReActAgentState.class, JSONReader.Feature.SupportClassForName);
// after
return JSON.parseObject(json, ReActAgentState.class, JSONReader.Feature.SupportAutoType);
```

之所以选择 `SupportAutoType` 而非窄范围的 `JSONReader.autoTypeFilter(...)` 白名单：序列化后的对象图同时跨越 `com.agentsflex.*` 与 `java.util.*`（每个消息的 `metadataMap` 里还嵌套了 `List<Tool>`、集合等），白名单需要逐一枚举包名、较为脆弱。`SupportAutoType` 能稳健覆盖整个对象图，且 fastjson2 内置的危险类（gadget）黑名单在该模式下依然生效。

## 测试 / Tests

新增离线回归测试 `ReActAgentStateTest`（不依赖网络 / LLM）：

- `toJSON() → fromJSON()` 往返，断言 `messageHistory` 中的 `UserMessage` / `AiMessage` 子类型与 `content`、metadata、标量字段都被正确还原。
- 已验证：将修复回退后，该测试以 issue 中**完全一致**的异常失败（`create instance error … InstantiationException`）；应用修复后通过。
- `agents-flex-core` 全量测试通过：**33 个，0 失败，0 错误**。

Closes #50
