### PR TITLE
feat: add Tavily search provider option to websearch demo

### DIFF
--- a/demos/websearch-demo/src/main/java/com/agentsflex/websearch/WebSearchDemo.java
+++ b/demos/websearch-demo/src/main/java/com/agentsflex/websearch/WebSearchDemo.java
@@ -17,6 +17,7 @@ import com.agentsflex.model.chat.openai.OpenAIChatModel;
 import com.agentsflex.tool.commons.TodoWriteTool;
 import com.agentsflex.tool.commons.WebFetchTool;
 import com.agentsflex.websearch.baidu.BaiduQianfanSearchProvider;
+import com.agentsflex.websearch.tavily.TavilySearchProvider;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 
@@ -69,6 +70,7 @@ public class WebSearchDemo {
         prompt.addTools(ToolScanner.scan(WebFetchTool.builder().useDefaultProviders().build()));
         prompt.addTools(ToolScanner.scan(WebSearchTool.builder()
 //            .provider(new BochaSearchProvider(System.getenv("BOCHA_APIKEY")))
+//            .provider(new TavilySearchProvider(System.getenv("TAVILY_API_KEY")))
             .provider(new BaiduQianfanSearchProvider(System.getenv("BAIDU_APIKEY")))
             .build()));
 


### PR DESCRIPTION
## Summary

Adds TavilySearchProvider as a third commented-out search provider option in the websearch demo, following the existing pattern where BochaSearchProvider is already commented out alongside the active BaiduQianfanSearchProvider.

This is a purely additive change — developers can now easily switch to Tavily by uncommenting the Tavily line and commenting out the Baidu line.

## Files Changed

- `demos/websearch-demo/src/main/java/com/agentsflex/websearch/WebSearchDemo.java`
  - Added import for `com.agentsflex.websearch.tavily.TavilySearchProvider`
  - Added commented-out `.provider(new TavilySearchProvider(System.getenv("TAVILY_API_KEY")))` line

## Environment Variable Changes

- `TAVILY_API_KEY` — required when uncommenting the Tavily provider option

## Notes for Reviewers

- No dependency changes needed; the demo depends on agents-flex-websearch which provides the TavilySearchProvider class.
- The existing BaiduQianfanSearchProvider remains the active default — no behavior change.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The change correctly adds TavilySearchProvider as a commented-out alternative provider option in WebSearchDemo.java, consistent with the additive migration strategy and the existing BochaSearchProvider pattern. The active provider is preserved. No pom.xml changes are needed since TavilySearchProvider will reside in the already-depended-upon agents-flex-websearch module (per the prerequisite unit). One issue: an import for TavilySearchProvider was added even though the class is only referenced in a comment, creating an unused import that is inconsistent with how BochaSearchProvider is handled (no import for it).
