### PR TITLE
feat: document Tavily search provider in websearch guide

### DIFF
--- a/docs/zh/chat/websearch.md
+++ b/docs/zh/chat/websearch.md
@@ -250,7 +250,31 @@ String results = searchTool.webSearch(
 ```
 
 
-#### 示例 3：与 LLM Agent 集成
+#### 示例 3：使用 Tavily Search
+
+```java
+import com.agentsflex.websearch.WebSearchTool;
+import com.agentsflex.websearch.tavily.TavilySearchProvider;
+
+// 创建 Tavily 搜索引擎提供商（需要 API Key）
+TavilySearchProvider provider = new TavilySearchProvider(
+    System.getenv("TAVILY_API_KEY")
+);
+
+// 创建搜索工具
+WebSearchTool searchTool = new WebSearchTool(provider);
+
+// 直接调用搜索
+String results = searchTool.webSearch(
+    "Java 17 new features",
+    null,  // 不限制域名
+    null   // 不屏蔽域名
+);
+
+System.out.println(results);
+```
+
+#### 示例 4：与 LLM Agent 集成
 
 ```java
 import com.agentsflex.core.agent.Agent;
@@ -288,6 +312,7 @@ System.out.println(response);
 export BRAVE_API_KEY="your-brave-search-api-key"
 export BOCHA_API_KEY="your-bocha-api-key"
 export BAIDU_QIANFAN_API_KEY="your-baidu-api-key"
+export TAVILY_API_KEY="your-tavily-api-key"
 ```
 
 
@@ -465,6 +490,7 @@ String results = tool.webSearch("Kubernetes deployment guide", null, null);
 | 百度千帆 | `baidu/BaiduQianfanSearchProvider.java` | https://cloud.baidu.com/doc/WENXINWORKSHOP/index.html        |
 | Bocha | `bocha/BochaSearchProvider.java` | https://bocha-ai.feishu.cn/wiki/HmtOw1z6vik14Fkdu5uc9VaInBb  |
 | Brave | `brave/BraveSearchProvider.java` | https://api.search.brave.com/app/documentation               |
+| Tavily | `tavily/TavilySearchProvider.java` | https://docs.tavily.com                                      |
 
 
 


### PR DESCRIPTION
## Summary

Adds Tavily as a documented search provider option in the Chinese websearch developer guide (`docs/zh/chat/websearch.md`). This is an additive change — all existing provider documentation is preserved.

### Changes made:

- **Section 4.2** — Added a new code example (示例 3) showing `TavilySearchProvider` instantiation with `TAVILY_API_KEY` environment variable
- **Section 4.3** — Added `TAVILY_API_KEY` to the environment configuration bash snippet
- **Section 5.4** — Added a Tavily row to the provider reference table with file path `tavily/TavilySearchProvider.java` and API docs link `https://docs.tavily.com`

## Files changed

- `docs/zh/chat/websearch.md`

## Environment variable changes

- Added `TAVILY_API_KEY` reference to the env config example

## Notes for reviewers

- Documentation only — no Java source changes in this unit
- The `TavilySearchProvider.java` implementation referenced in the docs does not yet exist in the codebase; it will be added in a separate migration unit
- All content is in Chinese (Simplified) to match existing documentation style


### Automated Review

- Passed after 1 attempt(s)
- Final review: The changes correctly implement all three steps from the migration plan: (1) added "示例 3：使用 Tavily Search" in section 4.2 with a well-formed Java code snippet using the correct import path `com.agentsflex.websearch.tavily.TavilySearchProvider` (matching the prerequisite unit's package), (2) added `TAVILY_API_KEY` to the environment config snippet in section 4.3, and (3) added a Tavily row to the provider reference table in section 5.4. The renumbering of the previous "示例 3" to "示例 4" is handled correctly. Only `docs/zh/chat/websearch.md` was modified. All changes are purely additive — no existing provider entries were removed. The code example follows the same style as the Brave Search example and uses `System.getenv()` for the API key, consistent with the security best practices documented in section 7.4.
