### PR TITLE
fix(core): strip markdown code fences from tool call arguments

### DIFF
--- a/agents-flex-core/src/main/java/com/agentsflex/core/message/ToolCall.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/message/ToolCall.java
@@ -80,6 +80,14 @@ public class ToolCall implements Serializable, Copyable<ToolCall> {
             lastException = e;
         }
 
+        String fencedJson = JsonSanitizer.stripMarkdownFences(originalJson);
+        if (!fencedJson.equals(originalJson)) {
+            try {
+                return JSON.parseObject(fencedJson);
+            } catch (RuntimeException e) {
+                lastException = e;
+            }
+        }
         try {
             String sanitizeJson = JsonSanitizer.sanitize(originalJson);
             return JSON.parseObject(sanitizeJson);

--- a/agents-flex-core/src/main/java/com/agentsflex/core/util/JsonSanitizer.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/util/JsonSanitizer.java
@@ -99,6 +99,48 @@ public final class JsonSanitizer {
         return result.toString();
     }
 
+
+    /**
+     * 剥离大模型输出中包裹工具参数的 markdown 代码围栏。
+     *
+     * <p>大模型经常把工具参数包在 markdown 代码块中输出，例如
+     * {@code ```json}{@code
+     * {"dataSourceName":"shixu"}}{@code ```}，这类文本无法被 JSON 解析器直接处理，
+     * 需要先取出围栏内部的 JSON 文本。</p>
+     *
+     * <p>方法按行扫描：取第一行围栏（{@code ```} 或 {@code ```json} 等）作为开头，
+     * 最后一行围栏作为结尾，返回中间的内容。文本没有成对围栏时原样返回，
+     * 交给后续容错策略处理。</p>
+     *
+     * @param text 可能被 markdown 代码围栏包裹的文本
+     * @return 围栏内部的 JSON 文本；文本不是围栏形式时原样返回
+     */
+    public static String stripMarkdownFences(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        String trimmed = text.trim();
+        String[] lines = trimmed.split("\n", -1);
+        Integer open = null;
+        Integer close = null;
+        for (int i = 0; i < lines.length; i++) {
+            String line = lines[i].trim();
+            if (line.startsWith("```")) {
+                if (open == null) {
+                    open = i;
+                }
+                else {
+                    close = i;
+                }
+            }
+        }
+        if (open == null || close == null || close <= open) {
+            return trimmed;
+        }
+        String[] inner = java.util.Arrays.copyOfRange(lines, open + 1, close);
+        return String.join("\n", inner).trim();
+    }
+
     /**
      * 从带有说明文字的模型输出中提取所有花括号配对完整的对象候选。
      *

--- a/agents-flex-core/src/test/java/com/agentsflex/core/message/ToolCallTest.java
+++ b/agents-flex-core/src/test/java/com/agentsflex/core/message/ToolCallTest.java
@@ -191,4 +191,36 @@ public class ToolCallTest {
         assertEquals(true, result.get("enabled"));
     }
 
+    @Test
+    public void testGetArgsMap_MarkdownFenceWithLanguage_ParsesSuccessfully() {
+        ToolCall toolCall = new ToolCall();
+        toolCall.setArguments("```json\n{\"dataSourceName\":\"shixu\",\"count\":3}\n```");
+
+        Map<String, Object> result = toolCall.getArgsMap();
+
+        assertEquals("shixu", result.get("dataSourceName"));
+        assertEquals(3, result.get("count"));
+    }
+
+    @Test
+    public void testGetArgsMap_MarkdownFenceWithoutLanguage_ParsesSuccessfully() {
+        ToolCall toolCall = new ToolCall();
+        toolCall.setArguments("```\n{\"name\":\"张三\"}\n```");
+
+        Map<String, Object> result = toolCall.getArgsMap();
+
+        assertEquals("张三", result.get("name"));
+    }
+
+    @Test
+    public void testGetArgsMap_MarkdownFenceWithPrefix_ParsesSuccessfully() {
+        ToolCall toolCall = new ToolCall();
+        toolCall.setArguments("Action Input:\n```json\n{\"dataSourceName\":\"shixu\"}\n```");
+
+        Map<String, Object> result = toolCall.getArgsMap();
+
+        assertEquals("shixu", result.get("dataSourceName"));
+    }
+
+
 }


### PR DESCRIPTION
## What
LLMs frequently wrap tool arguments in markdown code fences such as ```json ... ```, which the JSON parser cannot handle directly. Add JsonSanitizer.stripMarkdownFences() and try the stripped text in ToolCall.getArgsMap() before falling back to sanitization.

## Why
Fixes #61: when the model returns fenced arguments (e.g. ReAct "Action Input: ```json {...}```"), getArgsMap() throws instead of parsing. Non-fenced input takes the exact same code path as before.

## How verified
- Added 3 tests covering fenced args with/without a language tag and with a text prefix (the #61 scenario).
- mvn -pl agents-flex-core test: 225 tests, 0 failures, 0 errors.