### PR TITLE
fix(core): preserve routed stream lifecycle

### DIFF
--- a/agents-flex-core/src/main/java/com/agentsflex/core/model/router/chat/RoutedChatModel.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/model/router/chat/RoutedChatModel.java
@@ -201,8 +201,9 @@ public class RoutedChatModel extends AbstractModelRouter<ChatModel> implements C
         endpoint.getMetrics().beginRequest();
         long start = System.currentTimeMillis();
         // 回调可能来自网络线程，以下状态用于保证一次请求只结算一次。
-        AtomicBoolean delivered = new AtomicBoolean(); // 是否已向业务侧交付任意模型内容
-        AtomicBoolean opened = new AtomicBoolean();    // 是否已向业务侧发出 onOpen
+        AtomicBoolean delivered = new AtomicBoolean();        // 是否已向业务侧交付任意模型内容
+        AtomicBoolean providerOpened = new AtomicBoolean();   // 当前 Provider 是否已发出 onOpen
+        AtomicBoolean downstreamOpened = new AtomicBoolean(); // 是否已向业务侧发出 onOpen
         AtomicBoolean failed = new AtomicBoolean();
         AtomicBoolean finished = new AtomicBoolean();
         AtomicBoolean switched = new AtomicBoolean();   // 当前失败是否已交由备用节点接管
@@ -211,7 +212,7 @@ public class RoutedChatModel extends AbstractModelRouter<ChatModel> implements C
             @Override
             public void onOpen(StreamContext context) {
                 // 延迟转发。若连接刚打开就失败，业务侧只会看到最终选中节点的一次 onOpen。
-                opened.set(true);
+                providerOpened.set(true);
             }
 
             @Override
@@ -223,7 +224,7 @@ public class RoutedChatModel extends AbstractModelRouter<ChatModel> implements C
                 }
                 // 一旦内容已可见，不能再切换模型，否则会出现重复或混合输出。
                 delivered.set(true);
-                if (opened.compareAndSet(false, true)) listener.onOpen(context);
+                openDownstream(context);
                 listener.onMessage(context, response);
             }
 
@@ -247,26 +248,48 @@ public class RoutedChatModel extends AbstractModelRouter<ChatModel> implements C
                     return;
                 }
                 // 已经输出过内容，或异常不可重试：保持原流的生命周期并交由调用方处理。
-                if (opened.compareAndSet(false, true)) listener.onOpen(context);
-                listener.onError(context, error);
+                if (providerOpened.get() || downstreamOpened.get()) {
+                    openDownstream(context);
+                    listener.onError(context, error);
+                    return;
+                }
+                // Provider 在 onOpen 前失败时，契约允许只发送 onError；此时不会再有 onClose
+                // 可用于结算指标，因此必须在错误回调内结束当前请求。
+                finished.set(true);
+                try {
+                    listener.onError(context, error);
+                } finally {
+                    endpoint.getMetrics().recordFailure(System.currentTimeMillis() - start);
+                    if (shouldRecordEndpointFailure(error)) circuitBreaker.recordFailure(endpoint);
+                    endpoint.getMetrics().endRequest();
+                }
             }
 
             @Override
             public void onClose(StreamContext context) {
                 if (!finished.compareAndSet(false, true)) return;
-                if (!switched.get()) {
-                    listener.onClose(context);
-                    if (failed.get()) {
-                        endpoint.getMetrics().recordFailure(System.currentTimeMillis() - start);
-                        if (shouldRecordEndpointFailure(failure.get())) {
-                            circuitBreaker.recordFailure(endpoint);
+                try {
+                    if (!switched.get()) {
+                        // 正常空流没有 onMessage，仍需在 onClose 前补发延迟的 onOpen。
+                        if (providerOpened.get()) openDownstream(context);
+                        if (downstreamOpened.get()) listener.onClose(context);
+                        if (failed.get()) {
+                            endpoint.getMetrics().recordFailure(System.currentTimeMillis() - start);
+                            if (shouldRecordEndpointFailure(failure.get())) {
+                                circuitBreaker.recordFailure(endpoint);
+                            }
+                        } else {
+                            endpoint.getMetrics().recordSuccess(System.currentTimeMillis() - start);
+                            circuitBreaker.recordSuccess(endpoint);
                         }
-                    } else {
-                        endpoint.getMetrics().recordSuccess(System.currentTimeMillis() - start);
-                        circuitBreaker.recordSuccess(endpoint);
                     }
+                } finally {
+                    endpoint.getMetrics().endRequest();
                 }
-                endpoint.getMetrics().endRequest();
+            }
+
+            private void openDownstream(StreamContext context) {
+                if (downstreamOpened.compareAndSet(false, true)) listener.onOpen(context);
             }
         };
         try {

--- a/agents-flex-core/src/test/java/com/agentsflex/core/model/router/RoutedChatModelTest.java
+++ b/agents-flex-core/src/test/java/com/agentsflex/core/model/router/RoutedChatModelTest.java
@@ -20,7 +20,9 @@ import com.agentsflex.core.prompt.SimplePrompt;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -141,32 +143,94 @@ public class RoutedChatModelTest {
     }
 
     @Test
-    public void streamFailsBeforeMessageAndSwitchesOnce() {
-        FakeModel bad = new FakeModel((p, o, l) -> l.onError(new StreamContext(null, null, null),
-            new ModelRateLimitException("x", 429, null, null, null)));
-        FakeModel good = new FakeModel((p, o, l) -> {
+    public void streamPreservesNormalLifecycleOrder() {
+        FakeModel model = new FakeModel((p, o, l) -> {
             StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
             l.onMessage(c, new AiMessageResponse(null, null, new AiMessage("ok")));
             l.onClose(c);
         });
-        AtomicInteger messages = new AtomicInteger(), opens = new AtomicInteger();
-        router(Arrays.asList(bad, good)).chatStream(PROMPT, new StreamResponseListener() {
-            public void onOpen(StreamContext c) {
-                opens.incrementAndGet();
-            }
+        List<String> events = new ArrayList<>();
 
-            public void onMessage(StreamContext c, AiMessageResponse r) {
-                messages.incrementAndGet();
-            }
-        }, new ChatOptions());
-        Assert.assertEquals(1, opens.get());
-        Assert.assertEquals(1, messages.get());
+        singleRouter(model).chatStream(PROMPT, recordingListener(events), new ChatOptions());
+
+        Assert.assertEquals(Arrays.asList("open", "message", "close"), events);
+    }
+
+    @Test
+    public void emptyStreamStillOpensBeforeClose() {
+        FakeModel model = new FakeModel((p, o, l) -> {
+            StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
+            l.onClose(c);
+        });
+        List<String> events = new ArrayList<>();
+
+        singleRouter(model).chatStream(PROMPT, recordingListener(events), new ChatOptions());
+
+        Assert.assertEquals(Arrays.asList("open", "close"), events);
+    }
+
+    @Test
+    public void openedStreamFailurePreservesLifecycleOrder() {
+        FakeModel model = new FakeModel((p, o, l) -> {
+            StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
+            l.onError(c, new ModelQuotaExceededException("quota", 429, "insufficient_quota", null));
+            l.onClose(c);
+        });
+        List<String> events = new ArrayList<>();
+
+        singleRouter(model).chatStream(PROMPT, recordingListener(events), new ChatOptions());
+
+        Assert.assertEquals(Arrays.asList("open", "error", "close"), events);
+    }
+
+    @Test
+    public void failureBeforeOpenOnlyReportsErrorAndSettlesMetrics() {
+        FakeModel model = new FakeModel((p, o, l) -> l.onError(
+            new StreamContext(null, null, null),
+            new ModelQuotaExceededException("quota", 429, "insufficient_quota", null)));
+        ModelEndpoint<ChatModel> endpoint = new ModelEndpoint<>(model);
+        RoutedChatModel router = new RoutedChatModel(Collections.singletonList(endpoint),
+            new LeastActiveLoadBalancer<>(), new DefaultRetryPolicy(0), new CountingBreaker());
+        List<String> events = new ArrayList<>();
+
+        router.chatStream(PROMPT, recordingListener(events), new ChatOptions());
+
+        Assert.assertEquals(Collections.singletonList("error"), events);
+        Assert.assertEquals(0, endpoint.getMetrics().activeRequests());
+        Assert.assertEquals(1L, endpoint.getMetrics().failedRequests());
+    }
+
+    @Test
+    public void streamFailsBeforeMessageAndSwitchesOnce() {
+        FakeModel bad = new FakeModel((p, o, l) -> {
+            StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
+            l.onError(c, new ModelRateLimitException("x", 429, null, null, null));
+            l.onClose(c);
+        });
+        FakeModel good = new FakeModel((p, o, l) -> {
+            StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
+            l.onMessage(c, new AiMessageResponse(null, null, new AiMessage("ok")));
+            l.onClose(c);
+        });
+        List<String> events = new ArrayList<>();
+
+        router(Arrays.asList(bad, good)).chatStream(PROMPT, recordingListener(events), new ChatOptions());
+
+        Assert.assertEquals(Arrays.asList("open", "message", "close"), events);
+        Assert.assertEquals(1, bad.streamCalls.get());
+        Assert.assertEquals(1, good.streamCalls.get());
     }
 
     @Test
     public void streamFailureAfterMessageDoesNotSwitch() {
         FakeModel first = new FakeModel((p, o, l) -> {
             StreamContext c = new StreamContext(null, null, null);
+            l.onOpen(c);
             l.onMessage(c, new AiMessageResponse(null, null, new AiMessage("part")));
             l.onError(c, new RuntimeException("broken"));
             l.onClose(c);
@@ -188,6 +252,34 @@ public class RoutedChatModelTest {
         Assert.assertEquals(1, errors.get());
         Assert.assertEquals(1, closes.get());
         Assert.assertEquals(0, second.streamCalls.get());
+    }
+
+    private RoutedChatModel singleRouter(FakeModel model) {
+        return new RoutedChatModel(Collections.<ChatModel>singletonList(model));
+    }
+
+    private StreamResponseListener recordingListener(List<String> events) {
+        return new StreamResponseListener() {
+            @Override
+            public void onOpen(StreamContext context) {
+                events.add("open");
+            }
+
+            @Override
+            public void onMessage(StreamContext context, AiMessageResponse response) {
+                events.add("message");
+            }
+
+            @Override
+            public void onError(StreamContext context, Throwable error) {
+                events.add("error");
+            }
+
+            @Override
+            public void onClose(StreamContext context) {
+                events.add("close");
+            }
+        };
     }
 
     private RoutedChatModel router(List<FakeModel> models) {


### PR DESCRIPTION
## Summary

- separate the provider's open state from the downstream listener's onOpen delivery
- preserve onOpen -> onMessage/onError -> onClose ordering for normal, empty, and failed routed streams
- keep failures before provider open error-only and settle endpoint metrics without waiting for an onClose that may never arrive
- make the failover regression test use the same callback order as real stream providers

## Root cause

RoutedChatModel used one opened flag for two different facts. The wrapped provider onOpen callback set that flag without forwarding the event. When the first message arrived, the compare-and-set that should notify the downstream listener therefore failed, so normal routed streams skipped onOpen. Conversely, a failure before provider open could synthesize an onOpen without a matching onClose.

## Behavior covered

| Scenario | Before | After |
| --- | --- | --- |
| normal stream | message -> close | open -> message -> close |
| empty stream | close | open -> close |
| opened stream failure | error -> close | open -> error -> close |
| failure before open | open -> error and active metric leak | error with metrics settled |
| retry before first message | successful endpoint omitted open | one complete lifecycle from the successful endpoint |

## Tests

- mvn -pl agents-flex-core -Dtest=RoutedChatModelTest test (13 tests)
- mvn -pl agents-flex-core test (229 tests)
