### PR TITLE
feat(chat): add llmman as a local chat model provider

### DIFF
--- a/agents-flex-bom/pom.xml
+++ b/agents-flex-bom/pom.xml
@@ -173,6 +173,10 @@
         </dependency>
         <dependency>
             <groupId>com.agentsflex</groupId>
+            <artifactId>agents-flex-chat-llmman</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.agentsflex</groupId>
             <artifactId>agents-flex-chat-ollama</artifactId>
         </dependency>
         <dependency>

--- a/agents-flex-chat/agents-flex-chat-llmman/pom.xml
+++ b/agents-flex-chat/agents-flex-chat-llmman/pom.xml
@@ -5,27 +5,25 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.agentsflex</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>agents-flex-chat</artifactId>
         <version>${revision}</version>
     </parent>
 
-    <name>agents-flex-chat</name>
-    <artifactId>agents-flex-chat</artifactId>
-
-    <packaging>pom</packaging>
-    <modules>
-        <module>agents-flex-chat-openai</module>
-        <module>agents-flex-chat-qwen</module>
-        <module>agents-flex-chat-ollama</module>
-        <module>agents-flex-chat-deepseek</module>
-        <module>agents-flex-chat-litellm</module>
-        <module>agents-flex-chat-llmman</module>
-    </modules>
+    <name>agents-flex-chat-llmman</name>
+    <artifactId>agents-flex-chat-llmman</artifactId>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.agentsflex</groupId>
+            <artifactId>agents-flex-chat-ollama</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/agents-flex-chat/agents-flex-chat-llmman/src/main/java/com/agentsflex/model/chat/llmman/LlmmanChatConfig.java
+++ b/agents-flex-chat/agents-flex-chat-llmman/src/main/java/com/agentsflex/model/chat/llmman/LlmmanChatConfig.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.llmman;
+
+import com.agentsflex.model.chat.ollama.OllamaChatConfig;
+
+/**
+ * Config for <a href="https://github.com/llmmanorg/llmman">llmman</a>, a local model runner
+ * serving the Ollama API on port 17434; {@link OllamaChatConfig} with a different provider and port.
+ */
+public class LlmmanChatConfig extends OllamaChatConfig {
+
+    private static final String DEFAULT_PROVIDER = "llmman";
+    private static final String DEFAULT_ENDPOINT = "http://localhost:17434";
+
+    public LlmmanChatConfig() {
+        setProvider(DEFAULT_PROVIDER);
+        setEndpoint(DEFAULT_ENDPOINT);
+    }
+
+}

--- a/agents-flex-chat/agents-flex-chat-llmman/src/main/java/com/agentsflex/model/chat/llmman/LlmmanChatModel.java
+++ b/agents-flex-chat/agents-flex-chat-llmman/src/main/java/com/agentsflex/model/chat/llmman/LlmmanChatModel.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.llmman;
+
+import com.agentsflex.core.model.chat.ChatInterceptor;
+import com.agentsflex.model.chat.ollama.OllamaChatModel;
+
+import java.util.List;
+
+/**
+ * Chat model for <a href="https://github.com/llmmanorg/llmman">llmman</a>: {@link OllamaChatModel}
+ * driven by a {@link LlmmanChatConfig}.
+ */
+public class LlmmanChatModel extends OllamaChatModel {
+
+    public LlmmanChatModel(LlmmanChatConfig config) {
+        super(config);
+    }
+
+    public LlmmanChatModel(LlmmanChatConfig config, List<ChatInterceptor> userInterceptors) {
+        super(config, userInterceptors);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
             </dependency>
             <dependency>
                 <groupId>com.agentsflex</groupId>
+                <artifactId>agents-flex-chat-llmman</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.agentsflex</groupId>
                 <artifactId>agents-flex-chat-ollama</artifactId>
                 <version>${revision}</version>
             </dependency>

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ It is suitable for building intelligent customer service, enterprise knowledge b
 | `agents-flex-agent` | Durable Agent runtime: Run state, snapshot recovery, Worker leases, approval, middleware, and events |
 | `agents-flex-agent-store` | JDBC and Redis persistence for Agent runs, commands, events, and artifacts |
 | `agents-flex-observability` | OpenTelemetry span and metric exporters with JDBC persistence |
-| `agents-flex-chat` | Chat model integrations: OpenAI-compatible APIs, Qwen, Ollama, DeepSeek, LiteLLM |
+| `agents-flex-chat` | Chat model integrations: OpenAI-compatible APIs, Qwen, Ollama, DeepSeek, LiteLLM, llmman |
 | `agents-flex-embedding` | Embedding model integrations: OpenAI, Ollama, Qwen |
 | `agents-flex-image` | Image model integrations: OpenAI, Gemini, Qwen, Alibaba Cloud, Gitee, Qianfan, SiliconFlow, Stability, Tencent, Volcengine |
 | `agents-flex-video` | Asynchronous video generation and editing: Alibaba Cloud Model Studio and Volcengine Ark |


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- New module `agents-flex-chat/agents-flex-chat-llmman` with `LlmmanChatConfig` and `LlmmanChatModel`, subclassing the Ollama classes and changing only the provider name (`llmman`) and default endpoint (`http://localhost:17434`).
- Registered in `agents-flex-chat/pom.xml`, root `dependencyManagement`, and `agents-flex-bom`, alphabetically next to the existing chat entries.
- Added llmman to the `agents-flex-chat` row in `readme.md` (`readme_zh.md` left untouched as a translation).
- No Spring Boot auto-configuration, following the `agents-flex-chat-litellm` precedent; happy to add it if wanted.

**Testing:** `mvn -q -B compile -pl agents-flex-chat/agents-flex-chat-llmman -am` and `mvn -q -B validate -pl agents-flex-bom` pass (JDK 17); not run against a live llmman server.

> AI-assisted, reviewed before submitting.
