### PR TITLE
feat(toolsearch): add semantic tool search provider

### DIFF
--- a/agents-flex-toolsearch/src/main/java/com/agentsflex/toolsearch/semantic/SemanticToolSearchProvider.java
+++ b/agents-flex-toolsearch/src/main/java/com/agentsflex/toolsearch/semantic/SemanticToolSearchProvider.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ * Licensed under the Apache License, Version 2.0.
+ */
+package com.agentsflex.toolsearch.semantic;
+
+import com.agentsflex.core.model.embedding.EmbeddingModel;
+import com.agentsflex.core.store.VectorData;
+import com.agentsflex.toolsearch.ToolInfo;
+import com.agentsflex.toolsearch.ToolParameterInfo;
+import com.agentsflex.toolsearch.ToolSearchProvider;
+import com.agentsflex.toolsearch.ToolSearchRequest;
+import com.agentsflex.toolsearch.ToolSearchResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * 基于 {@link EmbeddingModel} 的进程内语义 Tool 搜索 Provider。
+ *
+ * <p>Tool 元数据在 {@link #save(ToolInfo)} 时生成并缓存 Embedding，查询时只需要为 query
+ * 生成一次 Embedding，然后使用余弦相似度进行 O(n) 排序。该实现适合几十到几百个 Tool，
+ * 可以在不部署向量数据库的情况下补充默认词法 Provider 无法覆盖的同义表达和自然语言召回。</p>
+ *
+ * <p>用于 Embedding 的文本包含名称、描述、分类、标签和递归参数结构。{@link ToolInfo#getMetadata()}
+ * 不会自动参与 Embedding，因为任意业务 Metadata 可能包含敏感信息、内部标识或高噪声字段；需要参与
+ * 语义召回的业务词应放在 category、tags 或描述中。</p>
+ *
+ * <p>工具名称的规范化精确匹配始终优先于纯向量结果，避免模型已经明确给出 Tool 名称时被近义 Tool
+ * 覆盖。除此之外，结果按余弦相似度降序排列，同分时按名称排序以保证结果稳定。</p>
+ */
+public class SemanticToolSearchProvider implements ToolSearchProvider {
+
+    /** 默认最低余弦相似度。 */
+    public static final double DEFAULT_MIN_SCORE = 0.2d;
+
+    private final EmbeddingModel embeddingModel;
+    private final double minScore;
+    /** 同名更新以一个不可变条目原子替换 metadata 与 vector，避免读到混合版本。 */
+    private final ConcurrentMap<String, IndexedTool> index = new ConcurrentHashMap<>();
+
+    /**
+     * 使用默认最低相似度创建 Provider。
+     */
+    public SemanticToolSearchProvider(EmbeddingModel embeddingModel) {
+        this(embeddingModel, DEFAULT_MIN_SCORE);
+    }
+
+    /**
+     * 创建 Provider。
+     *
+     * @param embeddingModel Tool 与查询使用的 Embedding 模型
+     * @param minScore       最低余弦相似度，范围 [-1, 1]
+     */
+    public SemanticToolSearchProvider(EmbeddingModel embeddingModel, double minScore) {
+        if (embeddingModel == null) {
+            throw new IllegalArgumentException("EmbeddingModel must not be null");
+        }
+        if (Double.isNaN(minScore) || minScore < -1.0d || minScore > 1.0d) {
+            throw new IllegalArgumentException("minScore must be between -1 and 1");
+        }
+        this.embeddingModel = embeddingModel;
+        this.minScore = minScore;
+    }
+
+    /**
+     * 保存或覆盖 Tool 元数据，并立即刷新对应的缓存 Embedding。
+     *
+     * <p>先生成向量，再用单个索引条目发布 metadata 与 vector。Embedding 失败时旧索引保持可用；
+     * 成功后同名更新对并发搜索线程表现为一次原子替换。</p>
+     */
+    @Override
+    public void save(ToolInfo toolInfo) {
+        if (toolInfo == null || !hasText(toolInfo.getName())) {
+            throw new IllegalArgumentException("ToolInfo and its name must not be blank");
+        }
+        float[] vector = embed(searchableText(toolInfo));
+        index.put(toolInfo.getName(), new IndexedTool(toolInfo, vector));
+    }
+
+    @Override
+    public ToolInfo findByName(String name) {
+        IndexedTool indexed = name == null ? null : index.get(name);
+        return indexed == null ? null : indexed.toolInfo;
+    }
+
+    @Override
+    public List<ToolInfo> findAll() {
+        List<ToolInfo> result = new ArrayList<>();
+        for (IndexedTool indexed : index.values()) result.add(indexed.toolInfo);
+        result.sort(Comparator.comparing(ToolInfo::getName));
+        return result;
+    }
+
+    /**
+     * 使用余弦相似度搜索 Tool。
+     *
+     * <p>category 使用规范化后的精确匹配。空 query 不调用 Embedding 模型，直接按名称返回分类范围内
+     * 的前 N 个 Tool，与默认内存 Provider 的空查询行为保持一致。</p>
+     */
+    @Override
+    public List<ToolSearchResult> search(ToolSearchRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("ToolSearchRequest must not be null");
+        }
+        String normalizedQuery = normalize(request.getQuery());
+        if (!hasText(normalizedQuery)) {
+            return unscoredResults(request);
+        }
+
+        float[] queryVector = embed(request.getQuery());
+        List<ToolSearchResult> results = new ArrayList<>();
+        for (IndexedTool indexed : index.values()) {
+            ToolInfo tool = indexed.toolInfo;
+            if (!matchesCategory(tool, request.getCategory())) continue;
+
+            boolean exactName = normalize(tool.getName()).equals(normalizedQuery);
+            double score = exactName ? 1.0d : cosineSimilarity(queryVector, indexed.vector);
+            if (exactName || score >= minScore) {
+                results.add(new ToolSearchResult(tool, score,
+                    Collections.singletonList(exactName ? "name" : "semantic")));
+            }
+        }
+        results.sort(Comparator
+            .comparing(SemanticToolSearchProvider::isExactNameResult)
+            .reversed()
+            .thenComparing(Comparator.comparingDouble(ToolSearchResult::getScore).reversed())
+            .thenComparing(result -> result.getToolInfo().getName()));
+        return limit(results, request.getMaxResults());
+    }
+
+    @Override
+    public boolean remove(String name) {
+        return name != null && index.remove(name) != null;
+    }
+
+    @Override
+    public void clear() {
+        index.clear();
+    }
+
+    /** @return 当前最低余弦相似度。 */
+    public double getMinScore() {
+        return minScore;
+    }
+
+    private List<ToolSearchResult> unscoredResults(ToolSearchRequest request) {
+        List<ToolInfo> candidates = new ArrayList<>();
+        for (IndexedTool indexed : index.values()) {
+            if (matchesCategory(indexed.toolInfo, request.getCategory())) candidates.add(indexed.toolInfo);
+        }
+        candidates.sort(Comparator.comparing(ToolInfo::getName));
+        List<ToolSearchResult> results = new ArrayList<>();
+        for (ToolInfo tool : candidates) {
+            results.add(new ToolSearchResult(tool, 0.0d, Collections.<String>emptyList()));
+        }
+        return limit(results, request.getMaxResults());
+    }
+
+    private static boolean isExactNameResult(ToolSearchResult result) {
+        return !result.getMatchedFields().isEmpty() && "name".equals(result.getMatchedFields().get(0));
+    }
+
+    private static boolean matchesCategory(ToolInfo tool, String category) {
+        return !hasText(category) || normalize(category).equals(normalize(tool.getCategory()));
+    }
+
+    private static <T> List<T> limit(List<T> values, int maxResults) {
+        return values.size() > maxResults
+            ? new ArrayList<>(values.subList(0, maxResults)) : values;
+    }
+
+    private float[] embed(String text) {
+        VectorData data = embeddingModel.embed(text);
+        if (data == null || data.getVector() == null || data.getVector().length == 0) {
+            throw new IllegalStateException("EmbeddingModel returned an empty vector");
+        }
+        return data.getVector().clone();
+    }
+
+    /**
+     * 将 Tool 元数据构造成稳定且有字段边界的可检索文本。
+     */
+    static String searchableText(ToolInfo tool) {
+        StringBuilder text = new StringBuilder();
+        appendField(text, "name", tool.getName());
+        appendField(text, "description", tool.getDescription());
+        appendField(text, "category", tool.getCategory());
+        if (!tool.getTags().isEmpty()) {
+            appendField(text, "tags", String.join(", ", tool.getTags()));
+        }
+        appendParameters(text, tool.getParameters(), "parameters");
+        return text.toString();
+    }
+
+    private static void appendParameters(StringBuilder text, List<ToolParameterInfo> parameters, String path) {
+        for (ToolParameterInfo parameter : parameters) {
+            if (parameter == null) continue;
+            String currentPath = path + "." + safe(parameter.getName());
+            StringBuilder value = new StringBuilder();
+            if (hasText(parameter.getName())) value.append(parameter.getName());
+            if (hasText(parameter.getType())) value.append(" type=").append(parameter.getType());
+            if (hasText(parameter.getDescription())) value.append(" ").append(parameter.getDescription());
+            if (parameter.isRequired()) value.append(" required");
+            appendField(text, currentPath, value.toString());
+            appendParameters(text, parameter.getChildren(), currentPath);
+        }
+    }
+
+    private static void appendField(StringBuilder text, String field, String value) {
+        if (!hasText(value)) return;
+        if (text.length() > 0) text.append('\n');
+        text.append(field).append(": ").append(value.trim());
+    }
+
+    private static double cosineSimilarity(float[] left, float[] right) {
+        if (left.length != right.length) {
+            throw new IllegalStateException("Embedding dimensions do not match: "
+                + left.length + " != " + right.length);
+        }
+        double dot = 0.0d;
+        double leftNorm = 0.0d;
+        double rightNorm = 0.0d;
+        for (int i = 0; i < left.length; i++) {
+            dot += (double) left[i] * right[i];
+            leftNorm += (double) left[i] * left[i];
+            rightNorm += (double) right[i] * right[i];
+        }
+        if (leftNorm == 0.0d || rightNorm == 0.0d) return 0.0d;
+        return dot / (Math.sqrt(leftNorm) * Math.sqrt(rightNorm));
+    }
+
+    private static String normalize(String value) {
+        if (value == null) return "";
+        return value.replaceAll("([\\p{Ll}\\d])(\\p{Lu})", "$1 $2")
+            .replaceAll("[^\\p{L}\\p{N}]+", " ").trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    /** metadata 与 vector 的不可变索引快照。 */
+    private static final class IndexedTool {
+        private final ToolInfo toolInfo;
+        private final float[] vector;
+
+        private IndexedTool(ToolInfo toolInfo, float[] vector) {
+            this.toolInfo = toolInfo;
+            this.vector = vector;
+        }
+    }
+}

--- a/agents-flex-toolsearch/src/test/java/com/agentsflex/toolsearch/semantic/SemanticToolSearchProviderTest.java
+++ b/agents-flex-toolsearch/src/test/java/com/agentsflex/toolsearch/semantic/SemanticToolSearchProviderTest.java
@@ -1,0 +1,160 @@
+package com.agentsflex.toolsearch.semantic;
+
+import com.agentsflex.core.document.Document;
+import com.agentsflex.core.model.chat.tool.Parameter;
+import com.agentsflex.core.model.chat.tool.Tool;
+import com.agentsflex.core.model.embedding.EmbeddingModel;
+import com.agentsflex.core.model.embedding.EmbeddingOptions;
+import com.agentsflex.core.store.VectorData;
+import com.agentsflex.toolsearch.ToolInfo;
+import com.agentsflex.toolsearch.ToolSearchRequest;
+import com.agentsflex.toolsearch.ToolSearchResult;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SemanticToolSearchProviderTest {
+
+    @Test
+    public void shouldRecallSemanticallyRelatedToolWithoutKeywordOverlap() {
+        RecordingEmbeddingModel embeddings = new RecordingEmbeddingModel();
+        SemanticToolSearchProvider provider = new SemanticToolSearchProvider(embeddings);
+        provider.save(info(tool("sendSlack", "Post a message to a Slack channel", "text"), "messaging"));
+        provider.save(info(tool("weatherLookup", "Fetch weather forecasts", "city"), "weather"));
+
+        List<ToolSearchResult> results = provider.search(
+            new ToolSearchRequest("notify my coworker in the team chat"));
+
+        assertEquals(1, results.size());
+        assertEquals("sendSlack", results.get(0).getToolInfo().getName());
+        assertEquals(Collections.singletonList("semantic"), results.get(0).getMatchedFields());
+    }
+
+    @Test
+    public void shouldCacheToolEmbeddingsAndEmbedEachQueryOnce() {
+        RecordingEmbeddingModel embeddings = new RecordingEmbeddingModel();
+        SemanticToolSearchProvider provider = new SemanticToolSearchProvider(embeddings, -1.0d);
+        provider.save(info(tool("sendSlack", "Post a message to Slack", "text"), "messaging"));
+        provider.save(info(tool("weatherLookup", "Fetch weather forecasts", "city"), "weather"));
+        assertEquals(2, embeddings.calls.get());
+
+        provider.search(new ToolSearchRequest("team chat"));
+        assertEquals(3, embeddings.calls.get());
+        provider.search(new ToolSearchRequest("forecast"));
+        assertEquals(4, embeddings.calls.get());
+    }
+
+    @Test
+    public void shouldPreferExactToolNameOverSemanticNeighbor() {
+        SemanticToolSearchProvider provider = new SemanticToolSearchProvider(new RecordingEmbeddingModel(), -1.0d);
+        provider.save(info(tool("sendSlack", "Post a message to Slack", "text"), "messaging"));
+        provider.save(info(tool("sendTeams", "Post a message to Microsoft Teams", "text"), "messaging"));
+
+        List<ToolSearchResult> results = provider.search(new ToolSearchRequest("sendSlack"));
+
+        assertEquals("sendSlack", results.get(0).getToolInfo().getName());
+        assertEquals(Collections.singletonList("name"), results.get(0).getMatchedFields());
+        assertEquals(1.0d, results.get(0).getScore(), 0.0d);
+    }
+
+    @Test
+    public void shouldApplyCategoryThresholdLimitAndCrudOperations() {
+        SemanticToolSearchProvider provider = new SemanticToolSearchProvider(new RecordingEmbeddingModel(), 0.8d);
+        provider.save(info(tool("sendSlack", "Post a message to Slack", "text"), "messaging"));
+        provider.save(info(tool("sendEmail", "Send an email", "body"), "email"));
+        provider.save(info(tool("weatherLookup", "Fetch weather forecasts", "city"), "weather"));
+
+        ToolSearchRequest request = new ToolSearchRequest("team chat");
+        request.setCategory("MESSAGING");
+        request.setMaxResults(1);
+        List<ToolSearchResult> results = provider.search(request);
+
+        assertEquals(1, results.size());
+        assertEquals("sendSlack", results.get(0).getToolInfo().getName());
+        assertTrue(provider.remove("sendSlack"));
+        assertNull(provider.findByName("sendSlack"));
+        assertEquals(2, provider.findAll().size());
+        provider.clear();
+        assertTrue(provider.findAll().isEmpty());
+    }
+
+    @Test
+    public void shouldNotEmbedArbitraryMetadataAndShouldIncludeParameters() {
+        ToolInfo info = info(tool("createTicket", "Create a support ticket", "priority"), "support");
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("apiKey", "secret-value");
+        info.setMetadata(metadata);
+
+        String text = SemanticToolSearchProvider.searchableText(info);
+
+        assertTrue(text.contains("createTicket"));
+        assertTrue(text.contains("priority"));
+        assertTrue(text.contains("support"));
+        assertFalse(text.contains("secret-value"));
+        assertFalse(text.contains("apiKey"));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldRejectMismatchedEmbeddingDimensions() {
+        SemanticToolSearchProvider provider = new SemanticToolSearchProvider(new MismatchedEmbeddingModel(), -1.0d);
+        provider.save(info(tool("sendSlack", "Post a message to Slack", "text"), "messaging"));
+        provider.search(new ToolSearchRequest("team chat"));
+    }
+
+    private static ToolInfo info(Tool tool, String category) {
+        ToolInfo info = ToolInfo.from(tool);
+        info.setCategory(category);
+        info.setTags(Arrays.asList("integration", category));
+        return info;
+    }
+
+    private static Tool tool(String name, String description, String parameterName) {
+        return Tool.builder(name).description(description)
+            .addParameter(Parameter.builder().name(parameterName)
+                .type("string").description("Value for " + parameterName).build())
+            .function(args -> name).build();
+    }
+
+    private static final class RecordingEmbeddingModel implements EmbeddingModel {
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Override
+        public VectorData embed(Document document, EmbeddingOptions options) {
+            calls.incrementAndGet();
+            String text = document.getContent() == null ? "" : document.getContent().toLowerCase();
+            if (text.contains("slack") || text.contains("team chat") || text.contains("coworker")) {
+                return vector(1.0f, 0.0f, 0.0f);
+            }
+            if (text.contains("teams")) return vector(0.95f, 0.05f, 0.0f);
+            if (text.contains("weather") || text.contains("forecast")) return vector(0.0f, 1.0f, 0.0f);
+            if (text.contains("email")) return vector(0.0f, 0.0f, 1.0f);
+            return vector(0.0f, 0.0f, 0.0f);
+        }
+    }
+
+    private static final class MismatchedEmbeddingModel implements EmbeddingModel {
+        private int calls;
+
+        @Override
+        public VectorData embed(Document document, EmbeddingOptions options) {
+            calls++;
+            return calls == 1 ? vector(1.0f, 0.0f) : vector(1.0f, 0.0f, 0.0f);
+        }
+    }
+
+    private static VectorData vector(float... values) {
+        VectorData data = new VectorData();
+        data.setVector(values);
+        return data;
+    }
+}


### PR DESCRIPTION
## Summary

Adds an in-memory semantic `ToolSearchProvider` backed by the existing `EmbeddingModel` abstraction, so tool discovery can recall capabilities even when the query and tool metadata do not share keywords.

## Why

The current `InMemoryToolSearchProvider` intentionally uses weighted lexical matching. That keeps the default lightweight, but it cannot handle synonym or intent-level matches such as a query like `notify my coworker in the team chat` for a tool described as `Post a message to a Slack channel`.

This PR keeps the existing lexical provider unchanged and adds semantic search as an opt-in provider. Keyword search remains the lightweight default, while embedding-based search is available when semantic recall is needed.

## Design

* Reuses the existing `EmbeddingModel`; no new runtime dependency.
* Embeds tool metadata on `save(...)` and caches the vector in memory.
* Embeds each search query once, then ranks tools by cosine similarity.
* Uses a configurable minimum similarity score (`0.2` by default).
* Preserves exact normalized tool-name matches as highest priority.
* Supports the existing `category` filter and `maxResults`.
* Embeds tool name, description, category, tags, and recursive parameter metadata.
* Deliberately excludes arbitrary `ToolInfo.metadata` to avoid sending potentially sensitive or noisy business metadata to an external embedding provider.
* Atomically replaces metadata + vector for same-name updates.
* Uses tool name as a stable tie-breaker.

Example:

```java
EmbeddingModel embeddingModel = ...;

ToolSearchTool toolSearch = ToolSearchTool.builder()
    .provider(new SemanticToolSearchProvider(embeddingModel))
    .addTools(applicationTools)
    .build();
```

A custom threshold can be configured with:

```java
new SemanticToolSearchProvider(embeddingModel, 0.35d);
```

## Tests

Adds deterministic unit tests with a fake `EmbeddingModel`, covering:

* semantic recall without keyword overlap
* cached tool embeddings and one query embedding per search
* exact-name priority
* category filtering, similarity threshold and top-K
* CRUD behavior
* exclusion of arbitrary metadata from embedding input
* embedding dimension mismatch handling

No external embedding API or vector database is required for the tests.
