### PR TITLE
feat(websearch): add You.com search provider

### DIFF
--- a/agents-flex-websearch/src/main/java/com/agentsflex/websearch/youcom/YouComSearchProvider.java
+++ b/agents-flex-websearch/src/main/java/com/agentsflex/websearch/youcom/YouComSearchProvider.java
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.websearch.youcom;
+
+import com.agentsflex.core.util.StringUtil;
+import com.agentsflex.websearch.SearchException;
+import com.agentsflex.websearch.SearchProvider;
+import com.agentsflex.websearch.SearchRequest;
+import com.agentsflex.websearch.SearchResult;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import okhttp3.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * You.com Web Search provider.
+ *
+ * <p>Requires a You.com API key: https://you.com/platform/api-keys
+ */
+public class YouComSearchProvider implements SearchProvider {
+
+    private static final String BASE_URL = "https://ydc-index.io/v1/search";
+    private static final MediaType JSON_MEDIA_TYPE = MediaType.parse("application/json");
+
+    private final String apiKey;
+    private final OkHttpClient httpClient;
+
+    public YouComSearchProvider(String apiKey) {
+        this(apiKey, new OkHttpClient());
+    }
+
+
+    public YouComSearchProvider(String apiKey, OkHttpClient httpClient) {
+
+        if (StringUtil.noText(apiKey)) {
+            throw new IllegalArgumentException("apiKey must not be empty");
+        }
+
+        if (httpClient == null) {
+            throw new IllegalArgumentException("OkHttpClient must not be null");
+        }
+
+        this.apiKey = apiKey;
+        this.httpClient = httpClient;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+
+    @Override
+    public List<SearchResult> search(SearchRequest request) {
+
+        if (request == null || StringUtil.noText(request.getQuery())) {
+            throw new RuntimeException("query keyword is null or blank.");
+        }
+
+        try {
+            String body = execute(request);
+
+            if (StringUtil.noText(body)) {
+                return Collections.emptyList();
+            }
+
+            JSONObject root = JSON.parseObject(body);
+            JSONObject results = root.getJSONObject("results");
+
+            if (results == null) {
+                return Collections.emptyList();
+            }
+
+            JSONArray arr = results.getJSONArray("web");
+
+            return parse(arr);
+        } catch (SearchException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SearchException("Failed to search with You.com", e);
+        }
+    }
+
+    // ---------------------------------------------------
+    // HTTP
+    // ---------------------------------------------------
+
+    private String execute(SearchRequest request) throws IOException {
+
+        JSONObject payload = new JSONObject();
+        payload.put("query", request.getQuery());
+        payload.put("count", request.getMaxResults());
+
+        List<String> allowedDomains = request.getAllowedDomains();
+        if (allowedDomains != null && !allowedDomains.isEmpty()) {
+            payload.put("include_domains", allowedDomains);
+        }
+
+        List<String> blockedDomains = request.getBlockedDomains();
+        if (blockedDomains != null && !blockedDomains.isEmpty()) {
+            payload.put("exclude_domains", blockedDomains);
+        }
+
+        RequestBody requestBody = RequestBody.create(payload.toJSONString(), JSON_MEDIA_TYPE);
+
+        Request httpRequest = new Request.Builder()
+            .url(BASE_URL)
+            .addHeader("Content-Type", "application/json")
+            .addHeader("X-API-Key", apiKey)
+            .post(requestBody)
+            .build();
+
+        try (Response response = httpClient.newCall(httpRequest).execute()) {
+
+            ResponseBody responseBody = response.body();
+            String body = responseBody != null ? responseBody.string() : "";
+
+            if (!response.isSuccessful()) {
+                throw new SearchException("You.com Search HTTP Error: " + response.code()
+                    + (StringUtil.hasText(body) ? ", body=" + body : ""));
+            }
+
+            return body;
+        }
+    }
+
+    private List<SearchResult> parse(JSONArray array) {
+
+        if (array == null || array.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<SearchResult> results = new ArrayList<>();
+
+        for (int i = 0; i < array.size(); i++) {
+
+            JSONObject item = array.getJSONObject(i);
+            if (item == null) continue;
+
+            String title = item.getString("title");
+            String url = item.getString("url");
+            String description = item.getString("description");
+
+            if (StringUtil.noText(title) || StringUtil.noText(url)) {
+                continue;
+            }
+
+            SearchResult r = new SearchResult();
+            r.setTitle(title);
+            r.setUrl(url);
+            r.setDescription(description);
+
+            results.add(r);
+        }
+
+        return results;
+    }
+}

--- a/agents-flex-websearch/src/test/java/com/agentsflex/websearch/youcom/YouComSearchProviderTest.java
+++ b/agents-flex-websearch/src/test/java/com/agentsflex/websearch/youcom/YouComSearchProviderTest.java
@@ -1,0 +1,114 @@
+package com.agentsflex.websearch.youcom;
+
+import com.agentsflex.websearch.SearchException;
+import com.agentsflex.websearch.SearchRequest;
+import com.agentsflex.websearch.SearchResult;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.Buffer;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class YouComSearchProviderTest {
+
+    @Test
+    public void shouldMapRequestAndParseWebResults() {
+        StubInterceptor interceptor = new StubInterceptor(200,
+            "{\"results\":{\"web\":["
+                + "{\"title\":\"First\",\"url\":\"https://example.com/one\",\"description\":\"Summary\"},"
+                + "{\"url\":\"https://example.com/missing-title\"}]}}"
+        );
+        YouComSearchProvider provider = new YouComSearchProvider("ydc-test", client(interceptor));
+        SearchRequest request = new SearchRequest();
+        request.setQuery("agents flex");
+        request.setMaxResults(5);
+        request.setAllowedDomains(Arrays.asList("agentsflex.com", "github.com"));
+        request.setBlockedDomains(Arrays.asList("example.net"));
+
+        List<SearchResult> results = provider.search(request);
+
+        assertEquals(1, results.size());
+        assertEquals("First", results.get(0).getTitle());
+        assertEquals("https://example.com/one", results.get(0).getUrl());
+        assertEquals("Summary", results.get(0).getDescription());
+        assertEquals("POST", interceptor.request.method());
+        assertEquals("https://ydc-index.io/v1/search", interceptor.request.url().toString());
+        assertEquals("ydc-test", interceptor.request.header("X-API-Key"));
+
+        JSONObject payload = JSON.parseObject(interceptor.requestBody);
+        assertEquals("agents flex", payload.getString("query"));
+        assertEquals(5, payload.getIntValue("count"));
+        assertEquals(Arrays.asList("agentsflex.com", "github.com"), payload.getList("include_domains", String.class));
+        assertEquals(Arrays.asList("example.net"), payload.getList("exclude_domains", String.class));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNoWebResults() {
+        StubInterceptor interceptor = new StubInterceptor(200, "{\"results\":{}}");
+        YouComSearchProvider provider = new YouComSearchProvider("ydc-test", client(interceptor));
+        SearchRequest request = new SearchRequest();
+        request.setQuery("agents flex");
+
+        List<SearchResult> results = provider.search(request);
+
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    public void shouldFailOnHttpError() {
+        StubInterceptor interceptor = new StubInterceptor(401, "{\"error\":\"Unauthorized\"}");
+        YouComSearchProvider provider = new YouComSearchProvider("invalid", client(interceptor));
+        SearchRequest request = new SearchRequest();
+        request.setQuery("agents flex");
+
+        SearchException exception = assertThrows(SearchException.class, () -> provider.search(request));
+
+        assertEquals("You.com Search HTTP Error: 401, body={\"error\":\"Unauthorized\"}",
+            exception.getMessage());
+    }
+
+    private static OkHttpClient client(Interceptor interceptor) {
+        return new OkHttpClient.Builder().addInterceptor(interceptor).build();
+    }
+
+    private static class StubInterceptor implements Interceptor {
+        private final int responseCode;
+        private final String responseBody;
+        private Request request;
+        private String requestBody;
+
+        private StubInterceptor(int responseCode, String responseBody) {
+            this.responseCode = responseCode;
+            this.responseBody = responseBody;
+        }
+
+        @Override
+        public Response intercept(Chain chain) throws IOException {
+            request = chain.request();
+            Buffer buffer = new Buffer();
+            request.body().writeTo(buffer);
+            requestBody = buffer.readUtf8();
+
+            return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(responseCode)
+                .message("stub")
+                .body(ResponseBody.create(responseBody, MediaType.parse("application/json")))
+                .build();
+        }
+    }
+}

--- a/demos/websearch-demo/src/main/java/com/agentsflex/websearch/WebSearchDemo.java
+++ b/demos/websearch-demo/src/main/java/com/agentsflex/websearch/WebSearchDemo.java
@@ -71,6 +71,7 @@ public class WebSearchDemo {
 //            .provider(new BochaSearchProvider(System.getenv("BOCHA_APIKEY")))
 //            .provider(new TavilySearchProvider(System.getenv("TAVILY_API_KEY")))
 //            .provider(new FirecrawlSearchProvider(System.getenv("FIRECRAWL_API_KEY")))
+//            .provider(new YouComSearchProvider(System.getenv("YDC_API_KEY")))
             .provider(new BaiduQianfanSearchProvider(System.getenv("BAIDU_APIKEY")))
             .build()));
 

--- a/docs/zh/chat/websearch.md
+++ b/docs/zh/chat/websearch.md
@@ -19,7 +19,7 @@
 
 ### 1.2 核心特性
 
-- **多提供商支持**：内置百度千帆、Bocha、Brave、Tavily、Firecrawl 等主流搜索引擎支持
+- **多提供商支持**：内置百度千帆、Bocha、Brave、Tavily、Firecrawl、You.com 等主流搜索引擎支持
 - **领域过滤**：支持白名单（allowedDomains）和黑名单（blockedDomains）域名过滤
 - **结果格式化**：自动将搜索结果转换为 Markdown 格式，便于 LLM 理解
 - **Builder 模式**：提供流畅的 API 构建方式
@@ -72,6 +72,7 @@ graph TB
     C --> F[BaiduQianfanSearchProvider]
     C --> G[TavilySearchProvider]
     C --> H[FirecrawlSearchProvider]
+    C --> K[YouComSearchProvider]
     C --> I[Custom Provider]
 
     B --> J[SearchRequest]
@@ -318,7 +319,23 @@ String results = searchTool.webSearch("Java 17 new features", null, null);
 System.out.println(results);
 ```
 
-#### 示例 5：与 ChatModel 集成
+#### 示例 5：使用 You.com Search
+
+```java
+import com.agentsflex.websearch.WebSearchTool;
+import com.agentsflex.websearch.youcom.YouComSearchProvider;
+
+// 创建 You.com 搜索引擎提供商（需要 API Key）
+YouComSearchProvider provider = new YouComSearchProvider(
+    System.getenv("YDC_API_KEY")
+);
+
+WebSearchTool searchTool = new WebSearchTool(provider);
+String results = searchTool.webSearch("Java 17 new features", null, null);
+System.out.println(results);
+```
+
+#### 示例 6：与 ChatModel 集成
 
 ```java
 WebSearchTool searchTool = new WebSearchTool(
@@ -344,6 +361,7 @@ export BOCHA_API_KEY="your-bocha-api-key"
 export BAIDU_QIANFAN_API_KEY="your-baidu-api-key"
 export TAVILY_API_KEY="your-tavily-api-key"
 export FIRECRAWL_API_KEY="your-firecrawl-api-key"
+export YDC_API_KEY="your-youcom-api-key"
 ```
 
 
@@ -523,6 +541,7 @@ String results = tool.webSearch("Kubernetes deployment guide", null, null);
 | Brave | `brave/BraveSearchProvider.java` | https://api.search.brave.com/app/documentation               |
 | Tavily | `tavily/TavilySearchProvider.java` | https://docs.tavily.com                                      |
 | Firecrawl | `firecrawl/FirecrawlSearchProvider.java` | https://docs.firecrawl.dev/features/search                   |
+| You.com | `youcom/YouComSearchProvider.java` | https://you.com/docs/api-reference/search/v1-search         |
 
 
 


### PR DESCRIPTION
## What

Adds a `YouComSearchProvider` to the `agents-flex-websearch` module, following the same shape as the existing Tavily/Brave/Firecrawl providers. You.com is a web search API built for LLM and agent use cases, so it fits naturally alongside the other providers.

- Endpoint: `POST https://ydc-index.io/v1/search` (auth via `X-API-Key` header)
- Maps `SearchRequest` to `query` / `count` / `include_domains` / `exclude_domains`
- Parses `results.web[]` into `SearchResult` (title / url / description), skipping entries missing title or url
- HTTP errors surface as `SearchException` with status code and body, matching the Firecrawl provider
- No new dependencies: OkHttp3 + FastJSON2, both already used by the module

## Usage

```java
SearchProvider provider = new YouComSearchProvider(System.getenv("YDC_API_KEY"));

WebSearchTool searchTool = new WebSearchTool(provider);
String results = searchTool.webSearch("Java 17 new features", null, null);
```

API keys are available at https://you.com/platform/api-keys.

## Changes

- `agents-flex-websearch/.../youcom/YouComSearchProvider.java` — the provider
- `agents-flex-websearch/.../youcom/YouComSearchProviderTest.java` — unit tests using the same stub-interceptor pattern as `FirecrawlSearchProviderTest`
- `docs/zh/chat/websearch.md` — usage example, env var, provider table, and architecture diagram entry
- `demos/websearch-demo/.../WebSearchDemo.java` — commented provider option alongside the other providers

This is fully opt-in: nothing changes for existing users unless they explicitly construct the provider.

## Validation

```bash
mvn -pl agents-flex-websearch -am compile -DskipTests   # passes
mvn -pl agents-flex-websearch test                       # 6/6 pass (3 new + 3 existing)
```

New tests cover request mapping (query, count, domain filters, `X-API-Key` header), parsing of `results.web` including malformed entries, empty results, and the HTTP error path.

Happy to adjust the shape if you prefer a different abstraction or naming convention.