### PR TITLE
feat(openai): add stateless Responses chat adapter

### DIFF
--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatConfig.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatConfig.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.model.chat.BaseChatConfig;
+
+/** Configuration for the stateless OpenAI Responses chat adapter. */
+public class OpenAIResponsesChatConfig extends BaseChatConfig {
+    public OpenAIResponsesChatConfig() {
+        setProvider("openai");
+        setEndpoint("https://api.openai.com");
+        setRequestPath("/v1/responses");
+        setModel("gpt-4.1");
+        setSupportTool(true);
+        setSupportToolMessage(true);
+    }
+
+    public OpenAIResponsesChatModel toChatModel() {
+        return new OpenAIResponsesChatModel(this);
+    }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatConfig.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatConfig.java
@@ -17,8 +17,18 @@ package com.agentsflex.model.chat.openai.responses;
 
 import com.agentsflex.core.model.chat.BaseChatConfig;
 
-/** Configuration for the stateless OpenAI Responses chat adapter. */
+/**
+ * OpenAI Responses 对话模型配置。
+ * <p>
+ * 默认使用 {@code https://api.openai.com/v1/responses} 和 {@code gpt-4.1}，
+ * 支持文本对话及本地函数工具。历史消息由调用方管理，不依赖服务端会话。
+ * API Key、模型名称等通用属性通过 {@link BaseChatConfig} 的访问方法配置。
+ */
 public class OpenAIResponsesChatConfig extends BaseChatConfig {
+
+    /**
+     * 创建使用默认 Endpoint、模型和工具能力的配置。
+     */
     public OpenAIResponsesChatConfig() {
         setProvider("openai");
         setEndpoint("https://api.openai.com");
@@ -28,6 +38,11 @@ public class OpenAIResponsesChatConfig extends BaseChatConfig {
         setSupportToolMessage(true);
     }
 
+    /**
+     * 使用当前配置创建 Responses 对话模型。
+     *
+     * @return 新的对话模型实例
+     */
     public OpenAIResponsesChatModel toChatModel() {
         return new OpenAIResponsesChatModel(this);
     }

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatModel.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatModel.java
@@ -17,14 +17,33 @@ package com.agentsflex.model.chat.openai.responses;
 
 import com.agentsflex.core.model.chat.BaseChatModel;
 import com.agentsflex.core.model.chat.ChatInterceptor;
+
 import java.util.List;
 
-/** Opt-in Responses protocol; existing OpenAIChatModel continues to use Chat Completions. */
+/**
+ * OpenAI Responses 对话模型实现。
+ * <p>
+ * 负责组装 Responses 请求构建器和客户端，同步与流式调用共用
+ * {@link BaseChatModel} 的拦截器、日志及上下文机制。
+ * 使用本类时显式选择 Responses 协议，现有 OpenAIChatModel 仍使用 Chat Completions。
+ */
 public class OpenAIResponsesChatModel extends BaseChatModel<OpenAIResponsesChatConfig> {
+
+    /**
+     * 构造模型，不配置实例级拦截器。
+     *
+     * @param config Responses 对话配置
+     */
     public OpenAIResponsesChatModel(OpenAIResponsesChatConfig config) {
         this(config, null);
     }
 
+    /**
+     * 构造模型，并将实例级拦截器交给基础模型统一管理。
+     *
+     * @param config       Responses 对话配置
+     * @param interceptors 实例级拦截器，可为 null 或空列表
+     */
     public OpenAIResponsesChatModel(OpenAIResponsesChatConfig config, List<ChatInterceptor> interceptors) {
         super(config, interceptors);
         setChatRequestSpecBuilder(new ResponsesRequestSpecBuilder());

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatModel.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/OpenAIResponsesChatModel.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.model.chat.BaseChatModel;
+import com.agentsflex.core.model.chat.ChatInterceptor;
+import java.util.List;
+
+/** Opt-in Responses protocol; existing OpenAIChatModel continues to use Chat Completions. */
+public class OpenAIResponsesChatModel extends BaseChatModel<OpenAIResponsesChatConfig> {
+    public OpenAIResponsesChatModel(OpenAIResponsesChatConfig config) {
+        this(config, null);
+    }
+
+    public OpenAIResponsesChatModel(OpenAIResponsesChatConfig config, List<ChatInterceptor> interceptors) {
+        super(config, interceptors);
+        setChatRequestSpecBuilder(new ResponsesRequestSpecBuilder());
+        setChatClient(new ResponsesChatClient(this));
+    }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesChatClient.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesChatClient.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.model.chat.*;
+import com.agentsflex.core.model.chat.response.AiMessageResponse;
+import com.agentsflex.core.model.client.*;
+
+/** Reuses HTTP transport while providing Responses-specific terminal and streaming parsing. */
+public class ResponsesChatClient extends OpenAIChatClient {
+    public ResponsesChatClient(BaseChatModel<?> model) { super(model); }
+
+    @Override
+    protected AiMessageResponse parseResponse(String raw, ChatContext context) {
+        return new ResponsesResponseParser().parse(raw, context);
+    }
+
+    @Override
+    public void chatStream(String body, StreamResponseListener listener) {
+        ChatContext context = ChatContextHolder.currentContext();
+        ChatRequestSpec spec = context.getRequestSpec();
+        StreamClient transport = getStreamClient();
+        ResponsesStreamListener bridge = new ResponsesStreamListener(chatModel, context, transport, listener);
+        try {
+            bridge.onStart(transport);
+            if (bridge.isTerminal()) return;
+            transport.start(spec.getUrl(), spec.getHeaders(), body, bridge, chatModel.getConfig());
+        } catch (Exception error) {
+            bridge.onFailure(transport, error);
+        }
+    }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesChatClient.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesChatClient.java
@@ -15,19 +15,53 @@
  */
 package com.agentsflex.model.chat.openai.responses;
 
-import com.agentsflex.core.model.chat.*;
+import com.agentsflex.core.model.chat.BaseChatModel;
+import com.agentsflex.core.model.chat.ChatContext;
+import com.agentsflex.core.model.chat.ChatContextHolder;
+import com.agentsflex.core.model.chat.StreamResponseListener;
 import com.agentsflex.core.model.chat.response.AiMessageResponse;
-import com.agentsflex.core.model.client.*;
+import com.agentsflex.core.model.client.ChatRequestSpec;
+import com.agentsflex.core.model.client.OpenAIChatClient;
+import com.agentsflex.core.model.client.StreamClient;
 
-/** Reuses HTTP transport while providing Responses-specific terminal and streaming parsing. */
+/**
+ * OpenAI Responses 协议客户端。
+ * <p>
+ * 复用 {@link OpenAIChatClient} 的同步 HTTP 传输和错误处理，
+ * 使用独立解析器及流式监听器处理 Responses 响应。
+ * 每次流式调用创建独立状态，客户端实例不保存请求级上下文。
+ */
 public class ResponsesChatClient extends OpenAIChatClient {
-    public ResponsesChatClient(BaseChatModel<?> model) { super(model); }
 
+    /**
+     * 创建绑定到指定模型的客户端。
+     *
+     * @param model 所属对话模型
+     */
+    public ResponsesChatClient(BaseChatModel<?> model) {
+        super(model);
+    }
+
+    /**
+     * 将同步请求的最终响应转换为框架消息或错误响应。
+     *
+     * @param raw     服务端原始 JSON
+     * @param context 本次调用的上下文
+     * @return 解析后的响应
+     */
     @Override
     protected AiMessageResponse parseResponse(String raw, ChatContext context) {
         return new ResponsesResponseParser().parse(raw, context);
     }
 
+    /**
+     * 发起 SSE 请求，由请求独享的监听器管理增量消息和终止事件。
+     * <p>
+     * 不在此处重放已开始的流，以免重复发送业务回调。
+     *
+     * @param body     已由请求构建器生成的请求体
+     * @param listener 业务响应监听器
+     */
     @Override
     public void chatStream(String body, StreamResponseListener listener) {
         ChatContext context = ChatContextHolder.currentContext();
@@ -35,8 +69,11 @@ public class ResponsesChatClient extends OpenAIChatClient {
         StreamClient transport = getStreamClient();
         ResponsesStreamListener bridge = new ResponsesStreamListener(chatModel, context, transport, listener);
         try {
+            // 先通知业务打开，允许业务在建立连接前取消请求。
             bridge.onStart(transport);
-            if (bridge.isTerminal()) return;
+            if (bridge.isTerminal()) {
+                return;
+            }
             transport.start(spec.getUrl(), spec.getHeaders(), body, bridge, chatModel.getConfig());
         } catch (Exception error) {
             bridge.onFailure(transport, error);

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesRequestSpecBuilder.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesRequestSpecBuilder.java
@@ -15,7 +15,12 @@
  */
 package com.agentsflex.model.chat.openai.responses;
 
-import com.agentsflex.core.message.*;
+import com.agentsflex.core.message.AiMessage;
+import com.agentsflex.core.message.Message;
+import com.agentsflex.core.message.SystemMessage;
+import com.agentsflex.core.message.ToolCall;
+import com.agentsflex.core.message.ToolMessage;
+import com.agentsflex.core.message.UserMessage;
 import com.agentsflex.core.model.chat.BaseChatConfig;
 import com.agentsflex.core.model.chat.ChatOptions;
 import com.agentsflex.core.model.client.OpenAIChatMessageSerializer;
@@ -23,10 +28,31 @@ import com.agentsflex.core.model.client.OpenAIChatRequestSpecBuilder;
 import com.agentsflex.core.prompt.Prompt;
 import com.agentsflex.core.util.Maps;
 import com.alibaba.fastjson2.JSON;
-import java.util.*;
 
-/** Maps framework messages to Responses input items without server-side conversation state. */
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Responses 请求构建器。
+ * <p>
+ * 将框架消息转换为 {@code input} 项，并映射工具定义、输出 Token 限制和结构化输出格式。
+ * URL、请求头及重试配置复用基础实现；本类不保存请求状态，可由模型并发复用。
+ */
 public class ResponsesRequestSpecBuilder extends OpenAIChatRequestSpecBuilder {
+
+    /**
+     * 基于拦截器处理后的参数生成 Responses 请求体。
+     *
+     * @param prompt    包含历史消息和工具定义的提示词
+     * @param options   本次请求的选项
+     * @param config    模型配置
+     * @param streaming 是否使用流式输出
+     * @return 序列化后的 JSON 请求体
+     * @throws IllegalArgumentException 输入包含当前适配器不支持的能力时抛出
+     */
     @Override
     public String buildRequestBody(Prompt prompt, ChatOptions options, BaseChatConfig config, boolean streaming) {
         Maps body = Maps.of("model", options.getModelOrDefault(config.getModel()))
@@ -40,12 +66,15 @@ public class ResponsesRequestSpecBuilder extends OpenAIChatRequestSpecBuilder {
         if (options.getStop() != null && !options.getStop().isEmpty()) {
             throw new IllegalArgumentException("Responses does not support stop sequences");
         }
+        // Responses 使用 text.format；JSON Schema 的 name、schema、strict 需要移到同一层。
         Map<String, Object> format = options.getResponseFormat();
         if (format != null && !format.isEmpty()) {
             Map<String, Object> target = new LinkedHashMap<>(format);
             if ("json_schema".equals(format.get("type"))) {
                 Object schema = target.remove("json_schema");
-                if (!(schema instanceof Map)) throw new IllegalArgumentException("json_schema must be an object");
+                if (!(schema instanceof Map)) {
+                    throw new IllegalArgumentException("json_schema must be an object");
+                }
                 target.putAll((Map<String, Object>) schema);
                 target.put("type", "json_schema");
             }
@@ -60,46 +89,66 @@ public class ResponsesRequestSpecBuilder extends OpenAIChatRequestSpecBuilder {
                 }
                 Map<String, Object> function = new LinkedHashMap<>((Map<String, Object>) tool.get("function"));
                 function.put("type", "function");
+                // 保留框架工具中可选参数的语义，避免服务端隐式启用严格模式。
                 function.put("strict", false);
                 flattened.add(function);
             }
             body.set("tools", flattened);
             body.setIfNotNull("tool_choice", prompt.getToolChoice());
         }
-        if (options.getExtraBody() != null) body.putAll(options.getExtraBody());
-        // This adapter replays local history, including opaque reasoning items.
+        if (options.getExtraBody() != null) {
+            body.putAll(options.getExtraBody());
+        }
+        // 最后检查扩展参数，避免服务端会话与本地历史回传同时生效。
         if (Boolean.TRUE.equals(body.get("background")) || body.containsKey("previous_response_id")
             || body.containsKey("conversation")) {
-            throw new IllegalArgumentException("Responses adapter uses local history; background and server-side conversations are unsupported");
+            throw new IllegalArgumentException(
+                "Responses adapter uses local history; background and server-side conversations are unsupported");
         }
         return body.toJSON();
     }
 
+    /**
+     * 按历史顺序转换消息，并保留工具调用的 call_id 和加密推理项。
+     *
+     * @param messages 框架历史消息
+     * @return Responses input 项
+     */
     private List<Object> input(List<Message> messages) {
         List<Object> items = new ArrayList<>();
         for (Message message : messages) {
             if (message instanceof ToolMessage) {
                 ToolMessage tool = (ToolMessage) message;
-                items.add(Maps.of("type", "function_call_output").set("call_id", tool.getToolCallId())
+                items.add(Maps.of("type", "function_call_output")
+                    .set("call_id", tool.getToolCallId())
                     .set("output", text(tool.getTextContent())));
             } else if (message instanceof AiMessage) {
                 AiMessage ai = (AiMessage) message;
+                // 加密推理项无法从正文或摘要还原，必须从消息元数据原样回传。
                 Object reasoning = ai.getMetadata(ResponsesResponseParser.REASONING_ITEMS);
-                if (reasoning instanceof String) items.addAll(JSON.parseArray((String) reasoning));
+                if (reasoning instanceof String) {
+                    items.addAll(JSON.parseArray((String) reasoning));
+                }
                 String content = ai.getTextContent();
-                if (content == null) content = ai.getFullContent();
-                if (content != null && !content.isEmpty()) items.add(Maps.of("role", "assistant").set("content", content));
+                if (content == null) {
+                    content = ai.getFullContent();
+                }
+                if (content != null && !content.isEmpty()) {
+                    items.add(Maps.of("role", "assistant").set("content", content));
+                }
                 if (ai.getToolCalls() != null) {
                     for (ToolCall call : ai.getToolCalls()) {
-                        items.add(Maps.of("type", "function_call").set("call_id", call.getId())
-                            .set("name", call.getName()).set("arguments", call.getArguments()));
+                        items.add(Maps.of("type", "function_call")
+                            .set("call_id", call.getId())
+                            .set("name", call.getName())
+                            .set("arguments", call.getArguments()));
                     }
                 }
             } else if (message instanceof UserMessage || message instanceof SystemMessage) {
                 if (message instanceof UserMessage) {
                     UserMessage user = (UserMessage) message;
-                    if (hasItems(user.getImageUrls()) || hasItems(user.getFileUrls())
-                        || hasItems(user.getAudioUrls()) || hasItems(user.getVideoUrls())) {
+                    if (hasItems(user.getImageUrls()) || hasItems(user.getFileUrls()) || hasItems(user.getAudioUrls())
+                        || hasItems(user.getVideoUrls())) {
                         throw new IllegalArgumentException("Responses adapter currently supports text input only");
                     }
                 }
@@ -112,6 +161,10 @@ public class ResponsesRequestSpecBuilder extends OpenAIChatRequestSpecBuilder {
         return items;
     }
 
-    private static boolean hasItems(List<?> values) { return values != null && !values.isEmpty(); }
-    private static String text(String value) { return value == null ? "" : value; }
+    private static boolean hasItems(List<?> values) {
+        return values != null && !values.isEmpty();
+    }
+    private static String text(String value) {
+        return value == null ? "" : value;
+    }
 }

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesRequestSpecBuilder.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesRequestSpecBuilder.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.message.*;
+import com.agentsflex.core.model.chat.BaseChatConfig;
+import com.agentsflex.core.model.chat.ChatOptions;
+import com.agentsflex.core.model.client.OpenAIChatMessageSerializer;
+import com.agentsflex.core.model.client.OpenAIChatRequestSpecBuilder;
+import com.agentsflex.core.prompt.Prompt;
+import com.agentsflex.core.util.Maps;
+import com.alibaba.fastjson2.JSON;
+import java.util.*;
+
+/** Maps framework messages to Responses input items without server-side conversation state. */
+public class ResponsesRequestSpecBuilder extends OpenAIChatRequestSpecBuilder {
+    @Override
+    public String buildRequestBody(Prompt prompt, ChatOptions options, BaseChatConfig config, boolean streaming) {
+        Maps body = Maps.of("model", options.getModelOrDefault(config.getModel()))
+            .set("input", input(prompt.getMessages()))
+            .set("store", false)
+            .set("include", Collections.singletonList("reasoning.encrypted_content"))
+            .setIf(streaming, "stream", true)
+            .setIfNotNull("temperature", options.getTemperature())
+            .setIfNotNull("top_p", options.getTopP())
+            .setIfNotNull("max_output_tokens", options.getMaxTokens());
+        if (options.getStop() != null && !options.getStop().isEmpty()) {
+            throw new IllegalArgumentException("Responses does not support stop sequences");
+        }
+        Map<String, Object> format = options.getResponseFormat();
+        if (format != null && !format.isEmpty()) {
+            Map<String, Object> target = new LinkedHashMap<>(format);
+            if ("json_schema".equals(format.get("type"))) {
+                Object schema = target.remove("json_schema");
+                if (!(schema instanceof Map)) throw new IllegalArgumentException("json_schema must be an object");
+                target.putAll((Map<String, Object>) schema);
+                target.put("type", "json_schema");
+            }
+            body.set("text", Maps.of("format", target));
+        }
+        List<Map<String, Object>> tools = new OpenAIChatMessageSerializer().serializeTools(prompt.getTools(), config);
+        if (tools != null && !tools.isEmpty()) {
+            List<Map<String, Object>> flattened = new ArrayList<>();
+            for (Map<String, Object> tool : tools) {
+                if (!"function".equals(tool.get("type"))) {
+                    throw new IllegalArgumentException("Responses adapter supports local function tools only");
+                }
+                Map<String, Object> function = new LinkedHashMap<>((Map<String, Object>) tool.get("function"));
+                function.put("type", "function");
+                function.put("strict", false);
+                flattened.add(function);
+            }
+            body.set("tools", flattened);
+            body.setIfNotNull("tool_choice", prompt.getToolChoice());
+        }
+        if (options.getExtraBody() != null) body.putAll(options.getExtraBody());
+        // This adapter replays local history, including opaque reasoning items.
+        if (Boolean.TRUE.equals(body.get("background")) || body.containsKey("previous_response_id")
+            || body.containsKey("conversation")) {
+            throw new IllegalArgumentException("Responses adapter uses local history; background and server-side conversations are unsupported");
+        }
+        return body.toJSON();
+    }
+
+    private List<Object> input(List<Message> messages) {
+        List<Object> items = new ArrayList<>();
+        for (Message message : messages) {
+            if (message instanceof ToolMessage) {
+                ToolMessage tool = (ToolMessage) message;
+                items.add(Maps.of("type", "function_call_output").set("call_id", tool.getToolCallId())
+                    .set("output", text(tool.getTextContent())));
+            } else if (message instanceof AiMessage) {
+                AiMessage ai = (AiMessage) message;
+                Object reasoning = ai.getMetadata(ResponsesResponseParser.REASONING_ITEMS);
+                if (reasoning instanceof String) items.addAll(JSON.parseArray((String) reasoning));
+                String content = ai.getTextContent();
+                if (content == null) content = ai.getFullContent();
+                if (content != null && !content.isEmpty()) items.add(Maps.of("role", "assistant").set("content", content));
+                if (ai.getToolCalls() != null) {
+                    for (ToolCall call : ai.getToolCalls()) {
+                        items.add(Maps.of("type", "function_call").set("call_id", call.getId())
+                            .set("name", call.getName()).set("arguments", call.getArguments()));
+                    }
+                }
+            } else if (message instanceof UserMessage || message instanceof SystemMessage) {
+                if (message instanceof UserMessage) {
+                    UserMessage user = (UserMessage) message;
+                    if (hasItems(user.getImageUrls()) || hasItems(user.getFileUrls())
+                        || hasItems(user.getAudioUrls()) || hasItems(user.getVideoUrls())) {
+                        throw new IllegalArgumentException("Responses adapter currently supports text input only");
+                    }
+                }
+                items.add(Maps.of("role", message instanceof UserMessage ? "user" : "system")
+                    .set("content", text(message.getTextContent())));
+            } else {
+                throw new IllegalArgumentException("Unsupported Responses message: " + message.getClass().getName());
+            }
+        }
+        return items;
+    }
+
+    private static boolean hasItems(List<?> values) { return values != null && !values.isEmpty(); }
+    private static String text(String value) { return value == null ? "" : value; }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesResponseParser.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesResponseParser.java
@@ -19,21 +19,45 @@ import com.agentsflex.core.message.AiMessage;
 import com.agentsflex.core.message.ToolCall;
 import com.agentsflex.core.model.chat.ChatContext;
 import com.agentsflex.core.model.chat.response.AiMessageResponse;
-import com.alibaba.fastjson2.*;
-import java.util.*;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 
-/** Parses terminal Responses objects and preserves encrypted reasoning for local history replay. */
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OpenAI Responses 最终响应解析器。
+ * <p>
+ * 支持 completed 和 incomplete 响应，将文本、拒答、工具调用及 Token 用量映射到框架消息。
+ * 加密推理项保存在消息元数据中，供后续本地历史回传使用。
+ * 解析过程不持有共享可变状态，同步客户端和流式终止事件可复用该实现。
+ */
 public class ResponsesResponseParser {
+
+    /**
+     * 消息元数据中的推理项键名；值为 JSON 字符串，便于消息复制和历史存储。
+     */
     public static final String REASONING_ITEMS = "openai.responses.reasoning_items";
 
+    /**
+     * 解析完整响应对象；流式调用应传入终止事件中的 response，而非整个事件。
+     *
+     * @param raw     完整响应的原始 JSON
+     * @param context 本次调用上下文
+     * @return 成功消息或携带服务端错误信息的响应
+     * @throws com.alibaba.fastjson2.JSONException 输入不是合法 JSON 时抛出，由客户端处理
+     */
     public AiMessageResponse parse(String raw, ChatContext context) {
         JSONObject root = JSON.parseObject(raw);
-        if (root == null) return AiMessageResponse.error(context, raw, "Empty Responses object");
+        if (root == null) {
+            return AiMessageResponse.error(context, raw, "Empty Responses object");
+        }
         JSONObject error = root.getJSONObject("error");
         String status = root.getString("status");
         if (error != null || !("completed".equals(status) || "incomplete".equals(status))) {
-            AiMessageResponse result = AiMessageResponse.error(context, raw,
-                error == null ? "Unexpected Responses status: " + status : error.getString("message"));
+            AiMessageResponse result = AiMessageResponse.error(
+                context, raw, error == null ? "Unexpected Responses status: " + status : error.getString("message"));
             if (error != null) {
                 result.setErrorCode(error.getString("code"));
                 result.setErrorType(error.getString("type"));
@@ -54,23 +78,32 @@ public class ResponsesResponseParser {
         List<Object> annotations = new ArrayList<>();
         List<ToolCall> calls = new ArrayList<>();
         JSONArray output = root.getJSONArray("output");
-        if (output == null) return AiMessageResponse.error(context, raw, "Missing Responses output");
+        if (output == null) {
+            return AiMessageResponse.error(context, raw, "Missing Responses output");
+        }
         for (int i = 0; i < output.size(); i++) {
             JSONObject item = output.getJSONObject(i);
             switch (item.getString("type")) {
                 case "message":
                     JSONArray content = item.getJSONArray("content");
-                    if (content == null) break;
+                    if (content == null) {
+                        break;
+                    }
                     for (int j = 0; j < content.size(); j++) {
                         JSONObject part = content.getJSONObject(j);
                         if ("output_text".equals(part.getString("type"))) {
                             append(text, part.getString("text"));
-                            if (part.getJSONArray("annotations") != null) annotations.addAll(part.getJSONArray("annotations"));
-                        } else if ("refusal".equals(part.getString("type"))) append(refusal, part.getString("refusal"));
+                            if (part.getJSONArray("annotations") != null) {
+                                annotations.addAll(part.getJSONArray("annotations"));
+                            }
+                        } else if ("refusal".equals(part.getString("type"))) {
+                            append(refusal, part.getString("refusal"));
+                        }
                     }
                     break;
                 case "function_call":
                     ToolCall call = new ToolCall();
+                    // 工具结果关联的是 call_id，而不是输出项自身的 id。
                     call.setId(item.getString("call_id"));
                     call.setName(item.getString("name"));
                     call.setArguments(item.getString("arguments"));
@@ -79,20 +112,35 @@ public class ResponsesResponseParser {
                 case "reasoning":
                     reasoningItems.add(item);
                     JSONArray summary = item.getJSONArray("summary");
-                    if (summary != null) for (int j = 0; j < summary.size(); j++) append(reasoning, summary.getJSONObject(j).getString("text"));
+                    if (summary != null) {
+                        for (int j = 0; j < summary.size(); j++) {
+                            append(reasoning, summary.getJSONObject(j).getString("text"));
+                        }
+                    }
                     break;
                 default:
-                    return AiMessageResponse.error(context, raw, "Unsupported Responses output item: " + item.getString("type"));
+                    return AiMessageResponse.error(
+                        context, raw, "Unsupported Responses output item: " + item.getString("type"));
             }
         }
         ai.setContent(text.toString());
         ai.setFullContent(text.toString());
-        if (reasoning.length() > 0) ai.setReasoningContent(reasoning.toString());
-        if (refusal.length() > 0) ai.setRefusal(refusal.toString());
-        if (!annotations.isEmpty()) ai.setAnnotations(annotations);
-        if (!reasoningItems.isEmpty()) ai.putMetadata(REASONING_ITEMS, JSON.toJSONString(reasoningItems));
-        // Never expose partial function arguments as executable calls.
-        if ("completed".equals(status)) ai.setToolCalls(calls);
+        if (reasoning.length() > 0) {
+            ai.setReasoningContent(reasoning.toString());
+        }
+        if (refusal.length() > 0) {
+            ai.setRefusal(refusal.toString());
+        }
+        if (!annotations.isEmpty()) {
+            ai.setAnnotations(annotations);
+        }
+        if (!reasoningItems.isEmpty()) {
+            ai.putMetadata(REASONING_ITEMS, JSON.toJSONString(reasoningItems));
+        }
+        // 未完成响应的函数参数可能被截断，不能交给 Agent 执行。
+        if ("completed".equals(status)) {
+            ai.setToolCalls(calls);
+        }
         ai.setFinishReason(calls.isEmpty() ? "stop" : "tool_calls");
         if ("incomplete".equals(status)) {
             JSONObject details = root.getJSONObject("incomplete_details");
@@ -112,5 +160,9 @@ public class ResponsesResponseParser {
         return new AiMessageResponse(context, raw, ai);
     }
 
-    private static void append(StringBuilder target, String value) { if (value != null) target.append(value); }
+    private static void append(StringBuilder target, String value) {
+        if (value != null) {
+            target.append(value);
+        }
+    }
 }

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesResponseParser.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesResponseParser.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.message.AiMessage;
+import com.agentsflex.core.message.ToolCall;
+import com.agentsflex.core.model.chat.ChatContext;
+import com.agentsflex.core.model.chat.response.AiMessageResponse;
+import com.alibaba.fastjson2.*;
+import java.util.*;
+
+/** Parses terminal Responses objects and preserves encrypted reasoning for local history replay. */
+public class ResponsesResponseParser {
+    public static final String REASONING_ITEMS = "openai.responses.reasoning_items";
+
+    public AiMessageResponse parse(String raw, ChatContext context) {
+        JSONObject root = JSON.parseObject(raw);
+        if (root == null) return AiMessageResponse.error(context, raw, "Empty Responses object");
+        JSONObject error = root.getJSONObject("error");
+        String status = root.getString("status");
+        if (error != null || !("completed".equals(status) || "incomplete".equals(status))) {
+            AiMessageResponse result = AiMessageResponse.error(context, raw,
+                error == null ? "Unexpected Responses status: " + status : error.getString("message"));
+            if (error != null) {
+                result.setErrorCode(error.getString("code"));
+                result.setErrorType(error.getString("type"));
+            }
+            return result;
+        }
+        AiMessage ai = new AiMessage();
+        ai.setId(root.getString("id"));
+        ai.setObject(root.getString("object"));
+        ai.setCreated(root.getLong("created_at"));
+        ai.setModel(root.getString("model"));
+        ai.setRole("assistant");
+        ai.setServiceTier(root.getString("service_tier"));
+        StringBuilder text = new StringBuilder();
+        StringBuilder reasoning = new StringBuilder();
+        StringBuilder refusal = new StringBuilder();
+        List<Object> reasoningItems = new ArrayList<>();
+        List<Object> annotations = new ArrayList<>();
+        List<ToolCall> calls = new ArrayList<>();
+        JSONArray output = root.getJSONArray("output");
+        if (output == null) return AiMessageResponse.error(context, raw, "Missing Responses output");
+        for (int i = 0; i < output.size(); i++) {
+            JSONObject item = output.getJSONObject(i);
+            switch (item.getString("type")) {
+                case "message":
+                    JSONArray content = item.getJSONArray("content");
+                    if (content == null) break;
+                    for (int j = 0; j < content.size(); j++) {
+                        JSONObject part = content.getJSONObject(j);
+                        if ("output_text".equals(part.getString("type"))) {
+                            append(text, part.getString("text"));
+                            if (part.getJSONArray("annotations") != null) annotations.addAll(part.getJSONArray("annotations"));
+                        } else if ("refusal".equals(part.getString("type"))) append(refusal, part.getString("refusal"));
+                    }
+                    break;
+                case "function_call":
+                    ToolCall call = new ToolCall();
+                    call.setId(item.getString("call_id"));
+                    call.setName(item.getString("name"));
+                    call.setArguments(item.getString("arguments"));
+                    calls.add(call);
+                    break;
+                case "reasoning":
+                    reasoningItems.add(item);
+                    JSONArray summary = item.getJSONArray("summary");
+                    if (summary != null) for (int j = 0; j < summary.size(); j++) append(reasoning, summary.getJSONObject(j).getString("text"));
+                    break;
+                default:
+                    return AiMessageResponse.error(context, raw, "Unsupported Responses output item: " + item.getString("type"));
+            }
+        }
+        ai.setContent(text.toString());
+        ai.setFullContent(text.toString());
+        if (reasoning.length() > 0) ai.setReasoningContent(reasoning.toString());
+        if (refusal.length() > 0) ai.setRefusal(refusal.toString());
+        if (!annotations.isEmpty()) ai.setAnnotations(annotations);
+        if (!reasoningItems.isEmpty()) ai.putMetadata(REASONING_ITEMS, JSON.toJSONString(reasoningItems));
+        // Never expose partial function arguments as executable calls.
+        if ("completed".equals(status)) ai.setToolCalls(calls);
+        ai.setFinishReason(calls.isEmpty() ? "stop" : "tool_calls");
+        if ("incomplete".equals(status)) {
+            JSONObject details = root.getJSONObject("incomplete_details");
+            String reason = details == null ? "incomplete" : details.getString("reason");
+            ai.setFinishReason("max_output_tokens".equals(reason) ? "length" : reason);
+        }
+        ai.putMetadata("openai.responses.status", status);
+        JSONObject usage = root.getJSONObject("usage");
+        if (usage != null) {
+            ai.setPromptTokens(usage.getInteger("input_tokens"));
+            ai.setCompletionTokens(usage.getInteger("output_tokens"));
+            ai.setTotalTokens(usage.getInteger("total_tokens"));
+            ai.setPromptTokensDetails(usage.getJSONObject("input_tokens_details"));
+            ai.setCompletionTokensDetails(usage.getJSONObject("output_tokens_details"));
+        }
+        ai.setFinished(true);
+        return new AiMessageResponse(context, raw, ai);
+    }
+
+    private static void append(StringBuilder target, String value) { if (value != null) target.append(value); }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesStreamListener.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesStreamListener.java
@@ -16,73 +16,124 @@
 package com.agentsflex.model.chat.openai.responses;
 
 import com.agentsflex.core.message.AiMessage;
-import com.agentsflex.core.model.chat.*;
+import com.agentsflex.core.model.chat.BaseChatConfig;
+import com.agentsflex.core.model.chat.ChatContext;
+import com.agentsflex.core.model.chat.ChatContextHolder;
+import com.agentsflex.core.model.chat.ChatModel;
+import com.agentsflex.core.model.chat.StreamResponseListener;
 import com.agentsflex.core.model.chat.response.AiMessageResponse;
-import com.agentsflex.core.model.client.*;
-import com.alibaba.fastjson2.*;
+import com.agentsflex.core.model.client.StreamClient;
+import com.agentsflex.core.model.client.StreamClientListener;
+import com.agentsflex.core.model.client.StreamContext;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+
 import java.io.IOException;
 import java.util.Map;
 
-/** One bridge per request. Tool calls are delivered only in the authoritative terminal snapshot. */
+/**
+ * 将 Responses SSE 事件转换为框架的流式回调。
+ * <p>
+ * 每个请求独立创建监听器，通过同步方法串行处理事件和业务取消。
+ * 正文和推理摘要按增量发送；工具调用以终止响应中的完整快照为准，
+ * 避免交错参数分片被错误合并或提前执行。
+ */
 class ResponsesStreamListener implements StreamClientListener {
+
     private final ChatContext chatContext;
     private final StreamClient transport;
     private final StreamResponseListener listener;
     private final StreamContext context;
     private final StringBuilder content = new StringBuilder();
     private final StringBuilder reasoning = new StringBuilder();
+    /** 是否已通知业务打开，用于去重客户端和底层传输的启动通知。 */
     private boolean opened;
+    /** 已收到终止响应、发生错误或主动取消；后续事件不再发送业务消息。 */
     private boolean terminal;
+    /** 是否已发送 onClose，保证关闭回调只执行一次。 */
     private boolean closed;
 
-    ResponsesStreamListener(ChatModel model, ChatContext chatContext, StreamClient transport, StreamResponseListener listener) {
+    /**
+     * 创建请求独享的事件桥接器，并对外暴露可区分主动取消的 StreamClient。
+     *
+     * @param model       所属对话模型
+     * @param chatContext 本次请求上下文
+     * @param transport   实际 SSE 传输
+     * @param listener    业务响应监听器
+     */
+    ResponsesStreamListener(
+        ChatModel model, ChatContext chatContext, StreamClient transport, StreamResponseListener listener) {
         this.chatContext = chatContext;
         this.transport = transport;
         this.listener = listener;
         this.context = new StreamContext(model, chatContext, new StreamClient() {
             @Override
-            public void start(String url, Map<String, String> headers, String payload,
-                                        StreamClientListener target, BaseChatConfig config) {
+            public void start(String url, Map<String, String> headers, String payload, StreamClientListener target,
+                BaseChatConfig config) {
                 throw new UnsupportedOperationException("Stream already started");
             }
+
             @Override
-            public void stop() { cancel(); }
+            public void stop() {
+                cancel();
+            }
         });
     }
 
     @Override
     public synchronized void onStart(StreamClient client) {
-        if (opened || terminal) return;
+        if (opened || terminal) {
+            return;
+        }
         opened = true;
         inContext(() -> listener.onOpen(context));
     }
 
     @Override
     public synchronized void onMessage(StreamClient client, String raw) {
-        if (terminal) return;
+        if (terminal) {
+            return;
+        }
         inContext(() -> {
             try {
                 JSONObject event = JSON.parseObject(raw);
                 String type = event.getString("type");
-                if ("response.completed".equals(type) || "response.incomplete".equals(type) || "response.failed".equals(type)) {
-                    AiMessageResponse response = new ResponsesResponseParser().parse(event.getString("response"), chatContext);
-                    if (response.isError()) { fail(response.toException()); return; }
+                if ("response.completed".equals(type) || "response.incomplete".equals(type)
+                    || "response.failed".equals(type)) {
+                    AiMessageResponse response =
+                        new ResponsesResponseParser().parse(event.getString("response"), chatContext);
+                    if (response.isError()) {
+                        fail(response.toException());
+                        return;
+                    }
                     AiMessage full = response.getMessage();
                     full.setFullContent(full.getContent());
                     full.setFullReasoningContent(full.getReasoningContent());
+                    // 最终消息只携带 fullContent，避免调用方再次追加已经收到的正文。
                     full.setContent("");
                     full.setReasoningContent(null);
                     context.setFullMessage(full);
                     terminal = true;
-                    try { listener.onMessage(context, response); } finally { try { close(); } finally { transport.stop(); } }
+                    try {
+                        listener.onMessage(context, response);
+                    } finally {
+                        try {
+                            close();
+                        } finally {
+                            transport.stop();
+                        }
+                    }
                 } else if ("error".equals(type)) {
                     AiMessageResponse error = AiMessageResponse.error(chatContext, raw, event.getString("message"));
                     error.setErrorCode(event.getString("code"));
                     fail(error.toException());
-                } else if ("response.output_text.delta".equals(type) || "response.reasoning_summary_text.delta".equals(type)) {
+                } else if ("response.output_text.delta".equals(type)
+                    || "response.reasoning_summary_text.delta".equals(type)) {
                     AiMessage delta = new AiMessage();
                     String value = event.getString("delta");
-                    if (value == null) return;
+                    if (value == null) {
+                        return;
+                    }
                     if ("response.output_text.delta".equals(type)) {
                         content.append(value);
                         delta.setContent(value);
@@ -94,13 +145,22 @@ class ResponsesStreamListener implements StreamClientListener {
                     delta.setFullReasoningContent(reasoning.toString());
                     listener.onMessage(context, new AiMessageResponse(chatContext, raw, delta));
                 }
-            } catch (Exception error) { fail(error); }
+            } catch (Exception error) {
+                fail(error);
+            }
         });
     }
 
     @Override
     public synchronized void onStop(StreamClient client) {
-        inContext(() -> { if (!terminal) fail(new IOException("Responses stream ended before a terminal event")); else close(); });
+        inContext(() -> {
+            // 底层连接关闭不等于模型正常完成，必须先收到协议终止事件。
+            if (!terminal) {
+                fail(new IOException("Responses stream ended before a terminal event"));
+            } else {
+                close();
+            }
+        });
     }
 
     @Override
@@ -108,30 +168,71 @@ class ResponsesStreamListener implements StreamClientListener {
         inContext(() -> fail(error));
     }
 
-    synchronized boolean isTerminal() { return terminal; }
+    /** @return 当前请求是否已完成、失败或被取消 */
+    synchronized boolean isTerminal() {
+        return terminal;
+    }
 
+    /**
+     * 处理业务主动取消，只关闭连接，不伪造成功消息或断流错误。
+     */
     private synchronized void cancel() {
         inContext(() -> {
-            if (terminal) return;
+            if (terminal) {
+                return;
+            }
             terminal = true;
-            try { close(); } finally { transport.stop(); }
+            try {
+                close();
+            } finally {
+                transport.stop();
+            }
         });
     }
 
+    /**
+     * 记录首次错误，并保证错误回调后关闭业务生命周期和底层连接。
+     */
     private void fail(Throwable error) {
-        if (terminal) return;
+        if (terminal) {
+            return;
+        }
         terminal = true;
         context.setThrowable(error);
-        try { listener.onError(context, error); } finally { try { close(); } finally { transport.stop(); } }
+        try {
+            listener.onError(context, error);
+        } finally {
+            try {
+                close();
+            } finally {
+                transport.stop();
+            }
+        }
     }
 
+    /** 通知业务关闭；传输层重复关闭时不重复回调。 */
     private void close() {
-        if (!closed) { closed = true; listener.onClose(context); }
+        if (!closed) {
+            closed = true;
+            listener.onClose(context);
+        }
     }
 
+    /**
+     * 为网络线程和取消回调绑定请求上下文，结束后恢复调用前的上下文。
+     * 嵌套调用可能来自业务回调，不能无条件清空原有上下文。
+     */
     private void inContext(Runnable action) {
         ChatContext previous = ChatContextHolder.currentContext();
         ChatContextHolder.set(chatContext);
-        try { action.run(); } finally { if (previous == null) ChatContextHolder.clear(); else ChatContextHolder.set(previous); }
+        try {
+            action.run();
+        } finally {
+            if (previous == null) {
+                ChatContextHolder.clear();
+            } else {
+                ChatContextHolder.set(previous);
+            }
+        }
     }
 }

--- a/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesStreamListener.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/main/java/com/agentsflex/model/chat/openai/responses/ResponsesStreamListener.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.message.AiMessage;
+import com.agentsflex.core.model.chat.*;
+import com.agentsflex.core.model.chat.response.AiMessageResponse;
+import com.agentsflex.core.model.client.*;
+import com.alibaba.fastjson2.*;
+import java.io.IOException;
+import java.util.Map;
+
+/** One bridge per request. Tool calls are delivered only in the authoritative terminal snapshot. */
+class ResponsesStreamListener implements StreamClientListener {
+    private final ChatContext chatContext;
+    private final StreamClient transport;
+    private final StreamResponseListener listener;
+    private final StreamContext context;
+    private final StringBuilder content = new StringBuilder();
+    private final StringBuilder reasoning = new StringBuilder();
+    private boolean opened;
+    private boolean terminal;
+    private boolean closed;
+
+    ResponsesStreamListener(ChatModel model, ChatContext chatContext, StreamClient transport, StreamResponseListener listener) {
+        this.chatContext = chatContext;
+        this.transport = transport;
+        this.listener = listener;
+        this.context = new StreamContext(model, chatContext, new StreamClient() {
+            @Override
+            public void start(String url, Map<String, String> headers, String payload,
+                                        StreamClientListener target, BaseChatConfig config) {
+                throw new UnsupportedOperationException("Stream already started");
+            }
+            @Override
+            public void stop() { cancel(); }
+        });
+    }
+
+    @Override
+    public synchronized void onStart(StreamClient client) {
+        if (opened || terminal) return;
+        opened = true;
+        inContext(() -> listener.onOpen(context));
+    }
+
+    @Override
+    public synchronized void onMessage(StreamClient client, String raw) {
+        if (terminal) return;
+        inContext(() -> {
+            try {
+                JSONObject event = JSON.parseObject(raw);
+                String type = event.getString("type");
+                if ("response.completed".equals(type) || "response.incomplete".equals(type) || "response.failed".equals(type)) {
+                    AiMessageResponse response = new ResponsesResponseParser().parse(event.getString("response"), chatContext);
+                    if (response.isError()) { fail(response.toException()); return; }
+                    AiMessage full = response.getMessage();
+                    full.setFullContent(full.getContent());
+                    full.setFullReasoningContent(full.getReasoningContent());
+                    full.setContent("");
+                    full.setReasoningContent(null);
+                    context.setFullMessage(full);
+                    terminal = true;
+                    try { listener.onMessage(context, response); } finally { try { close(); } finally { transport.stop(); } }
+                } else if ("error".equals(type)) {
+                    AiMessageResponse error = AiMessageResponse.error(chatContext, raw, event.getString("message"));
+                    error.setErrorCode(event.getString("code"));
+                    fail(error.toException());
+                } else if ("response.output_text.delta".equals(type) || "response.reasoning_summary_text.delta".equals(type)) {
+                    AiMessage delta = new AiMessage();
+                    String value = event.getString("delta");
+                    if (value == null) return;
+                    if ("response.output_text.delta".equals(type)) {
+                        content.append(value);
+                        delta.setContent(value);
+                    } else {
+                        reasoning.append(value);
+                        delta.setReasoningContent(value);
+                    }
+                    delta.setFullContent(content.toString());
+                    delta.setFullReasoningContent(reasoning.toString());
+                    listener.onMessage(context, new AiMessageResponse(chatContext, raw, delta));
+                }
+            } catch (Exception error) { fail(error); }
+        });
+    }
+
+    @Override
+    public synchronized void onStop(StreamClient client) {
+        inContext(() -> { if (!terminal) fail(new IOException("Responses stream ended before a terminal event")); else close(); });
+    }
+
+    @Override
+    public synchronized void onFailure(StreamClient client, Throwable error) {
+        inContext(() -> fail(error));
+    }
+
+    synchronized boolean isTerminal() { return terminal; }
+
+    private synchronized void cancel() {
+        inContext(() -> {
+            if (terminal) return;
+            terminal = true;
+            try { close(); } finally { transport.stop(); }
+        });
+    }
+
+    private void fail(Throwable error) {
+        if (terminal) return;
+        terminal = true;
+        context.setThrowable(error);
+        try { listener.onError(context, error); } finally { try { close(); } finally { transport.stop(); } }
+    }
+
+    private void close() {
+        if (!closed) { closed = true; listener.onClose(context); }
+    }
+
+    private void inContext(Runnable action) {
+        ChatContext previous = ChatContextHolder.currentContext();
+        ChatContextHolder.set(chatContext);
+        try { action.run(); } finally { if (previous == null) ChatContextHolder.clear(); else ChatContextHolder.set(previous); }
+    }
+}

--- a/agents-flex-chat/agents-flex-chat-openai/src/test/java/com/agentsflex/model/chat/openai/responses/ResponsesProtocolTest.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/test/java/com/agentsflex/model/chat/openai/responses/ResponsesProtocolTest.java
@@ -28,27 +28,42 @@ import org.junit.Test;
 import java.util.*;
 import static org.junit.Assert.*;
 
+/**
+ * Responses 协议契约测试。
+ * <p>
+ * 使用固定 JSON 样例和模拟传输验证请求映射、工具回传及流式生命周期，
+ * 不依赖真实服务或 API Key。回归测试同时覆盖取消和异常路径。
+ */
 public class ResponsesProtocolTest {
+
     private final OpenAIResponsesChatConfig config = new OpenAIResponsesChatConfig();
     private final ResponsesRequestSpecBuilder builder = new ResponsesRequestSpecBuilder();
     private final ResponsesResponseParser parser = new ResponsesResponseParser();
 
     private static JSONObject completed(Object... output) {
-        return JSON.parseObject(JSON.toJSONString(Maps.of("id", "resp_1").set("object", "response")
-            .set("status", "completed").set("model", "test-model").set("created_at", 123)
+        return JSON.parseObject(JSON.toJSONString(Maps.of("id", "resp_1")
+            .set("object", "response")
+            .set("status", "completed")
+            .set("model", "test-model")
+            .set("created_at", 123)
             .set("output", Arrays.asList(output))));
     }
 
     private static Object message(String text) {
-        return Maps.of("type", "message").set("role", "assistant").set("content",
-            Collections.singletonList(Maps.of("type", "output_text").set("text", text)));
+        return Maps.of("type", "message")
+            .set("role", "assistant")
+            .set("content", Collections.singletonList(Maps.of("type", "output_text").set("text", text)));
     }
 
     private static Object call(String id, String args) {
-        return Maps.of("type", "function_call").set("id", "item_" + id).set("call_id", id)
-            .set("name", "weather").set("arguments", args);
+        return Maps.of("type", "function_call")
+            .set("id", "item_" + id)
+            .set("call_id", id)
+            .set("name", "weather")
+            .set("arguments", args);
     }
 
+    /** 验证 Responses 字段映射，并确保请求中不混入 Chat Completions 专有字段。 */
     @Test
     public void mapsRequestAndDoesNotSendChatCompletionFields() {
         config.setApiKey("test-key");
@@ -60,17 +75,19 @@ public class ResponsesProtocolTest {
         assertTrue(body.getBooleanValue("stream"));
         assertFalse(body.getBooleanValue("store"));
         assertEquals("json_object", body.getJSONObject("text").getJSONObject("format").getString("type"));
-        for (String key : Arrays.asList("messages", "max_tokens", "response_format", "stream_options")) assertFalse(body.containsKey(key));
+        for (String key : Arrays.asList("messages", "max_tokens", "response_format", "stream_options"))
+            assertFalse(body.containsKey(key));
         ChatRequestSpec spec = builder.buildRequestSpec(prompt, options, config);
         assertEquals("https://api.openai.com/v1/responses", spec.getUrl());
         assertEquals("Bearer test-key", spec.getHeaders().get("Authorization"));
         assertFalse(JSON.parseObject(builder.buildRequestBody(prompt, options, config)).containsKey("stream"));
     }
 
+    /** 转换 Schema 层级时保留调用方原始 Options，避免并发复用受到影响。 */
     @Test
     public void flattensJsonSchemaWithoutMutatingOptions() {
-        Map<String, Object> schema = Maps.of("name", "answer").set("strict", true)
-            .set("schema", Maps.of("type", "object"));
+        Map<String, Object> schema =
+            Maps.of("name", "answer").set("strict", true).set("schema", Maps.of("type", "object"));
         ChatOptions options = ChatOptions.builder().responseFormatToJsonSchema(schema).build();
         JSONObject body = JSON.parseObject(builder.buildRequestBody(new SimplePrompt("hello"), options, config));
         JSONObject format = body.getJSONObject("text").getJSONObject("format");
@@ -80,19 +97,32 @@ public class ResponsesProtocolTest {
         assertTrue(options.getResponseFormat().containsKey("json_schema"));
     }
 
+    /** 验证多工具执行结果按 call_id 回传，且复制消息后加密推理项仍可恢复。 */
     @Test
     public void roundTripsFunctionCallsAndEncryptedReasoningThroughCopiedHistory() {
-        Object reasoning = Maps.of("type", "reasoning").set("id", "rs_1")
-            .set("encrypted_content", "opaque").set("summary", Collections.emptyList());
-        AiMessage ai = parser.parse(completed(reasoning, call("call_a", "{}"), call("call_b", "{}")).toJSONString(), null).getMessage();
+        Object reasoning = Maps.of("type", "reasoning")
+            .set("id", "rs_1")
+            .set("encrypted_content", "opaque")
+            .set("summary", Collections.emptyList());
+        AiMessage ai =
+            parser.parse(completed(reasoning, call("call_a", "{}"), call("call_b", "{}")).toJSONString(), null)
+                .getMessage();
         assertEquals("call_a", ai.getToolCalls().get(0).getId());
         assertEquals(2, ai.getToolCalls().size());
         SimplePrompt initial = new SimplePrompt("weather?");
         initial.addTool(new Tool() {
-            public String getName() { return "weather"; }
-            public String getDescription() { return "Weather"; }
-            public Parameter[] getParameters() { return new Parameter[0]; }
-            public Object invoke(Map<String, Object> args) { return "sunny"; }
+            public String getName() {
+                return "weather";
+            }
+            public String getDescription() {
+                return "Weather";
+            }
+            public Parameter[] getParameters() {
+                return new Parameter[0];
+            }
+            public Object invoke(Map<String, Object> args) {
+                return "sunny";
+            }
         });
         initial.setToolChoice("required");
         ChatContext context = new ChatContext();
@@ -102,7 +132,11 @@ public class ResponsesProtocolTest {
         List<Message> history = new ArrayList<>(initial.getMessages());
         history.add(ai.copy());
         history.addAll(results);
-        Prompt next = new Prompt() { public List<Message> getMessages() { return history; } };
+        Prompt next = new Prompt() {
+            public List<Message> getMessages() {
+                return history;
+            }
+        };
         next.addTools(initial.getTools());
         JSONObject body = JSON.parseObject(builder.buildRequestBody(next, new ChatOptions(), config));
         JSONArray input = body.getJSONArray("input");
@@ -116,21 +150,26 @@ public class ResponsesProtocolTest {
         assertFalse(tool.getBooleanValue("strict"));
     }
 
+    /** 解析多个文本项、Token 明细和独立的拒答内容。 */
     @Test
     public void parsesAllTextPartsUsageAndRefusal() {
         JSONObject response = completed(message("hello"), message(" world"));
-        response.put("usage", Maps.of("input_tokens", 10).set("output_tokens", 3).set("total_tokens", 13)
-            .set("input_tokens_details", Maps.of("cached_tokens", 2)));
+        response.put("usage",
+            Maps.of("input_tokens", 10)
+                .set("output_tokens", 3)
+                .set("total_tokens", 13)
+                .set("input_tokens_details", Maps.of("cached_tokens", 2)));
         AiMessage ai = parser.parse(response.toJSONString(), null).getMessage();
         assertEquals("hello world", ai.getContent());
         assertEquals(Integer.valueOf(13), ai.getTotalTokens());
         assertEquals(2, ai.getPromptTokensDetails().get("cached_tokens"));
         assertEquals("resp_1", ai.getId());
-        JSONObject refused = completed(Maps.of("type", "message").set("content",
-            Collections.singletonList(Maps.of("type", "refusal").set("refusal", "declined"))));
+        JSONObject refused = completed(Maps.of("type", "message")
+            .set("content", Collections.singletonList(Maps.of("type", "refusal").set("refusal", "declined"))));
         assertEquals("declined", parser.parse(refused.toJSONString(), null).getMessage().getRefusal());
     }
 
+    /** 响应被截断时保留正文，但不允许执行不完整的工具参数。 */
     @Test
     public void incompleteResponseDoesNotExecutePartialTools() {
         JSONObject response = completed(message("partial"), call("call_a", "{"));
@@ -142,15 +181,18 @@ public class ResponsesProtocolTest {
         assertEquals("partial", parsed.getMessage().getContent());
     }
 
+    /** 保留服务端错误码，并明确拒绝尚不支持的输出项和非终止状态。 */
     @Test
     public void returnsStructuredErrorsAndRejectsUnsupportedOutputs() {
-        AiMessageResponse error = parser.parse("{\"status\":\"failed\",\"error\":{\"message\":\"failed\",\"code\":\"server_error\"}}", null);
+        AiMessageResponse error =
+            parser.parse("{\"status\":\"failed\",\"error\":{\"message\":\"failed\",\"code\":\"server_error\"}}", null);
         assertTrue(error.isError());
         assertEquals("server_error", error.getErrorCode());
         assertTrue(parser.parse(completed(Maps.of("type", "web_search_call")).toJSONString(), null).isError());
         assertTrue(parser.parse("{\"status\":\"queued\"}", null).isError());
     }
 
+    /** 通过模型公开入口验证 URL、请求体、响应解析和上下文清理。 */
     @Test
     public void modelUsesResponsesClientEndToEnd() {
         config.setApiKey("test-key");
@@ -162,7 +204,8 @@ public class ResponsesProtocolTest {
             @Override
             public String post(String url, Map<String, String> headers, String payload) {
                 assertTrue(url.endsWith("/v1/responses"));
-                assertEquals("hello", JSON.parseObject(payload).getJSONArray("input").getJSONObject(0).getString("content"));
+                assertEquals(
+                    "hello", JSON.parseObject(payload).getJSONArray("input").getJSONObject(0).getString("content"));
                 return completed(message("answer")).toJSONString();
             }
         });
@@ -170,6 +213,7 @@ public class ResponsesProtocolTest {
         assertNull(ChatContextHolder.currentContext());
     }
 
+    /** 交错工具分片不提前下发，最终快照包含完整工具列表且不重复输出正文。 */
     @Test
     public void streamsTextOnceAndPublishesCompleteParallelCallsAtTerminalEvent() {
         Harness h = new Harness();
@@ -192,6 +236,7 @@ public class ResponsesProtocolTest {
         assertTrue(h.stopped);
     }
 
+    /** 异常断流和非法事件只通知一次失败，不生成伪成功消息。 */
     @Test
     public void prematureEofAndMalformedEventsFailWithoutFinishedMessage() {
         Harness h = new Harness();
@@ -208,11 +253,13 @@ public class ResponsesProtocolTest {
         assertEquals(1, malformed.closes);
     }
 
+    /** 区分服务端失败与业务取消，并验证关闭回调去重。 */
     @Test
     public void failedEventAndExplicitCancellationCloseExactlyOnce() {
         Harness h = new Harness();
         h.start();
-        h.send("response.failed", Maps.of("response", Maps.of("status", "failed").set("error", Maps.of("message", "failure"))));
+        h.send("response.failed",
+            Maps.of("response", Maps.of("status", "failed").set("error", Maps.of("message", "failure"))));
         assertEquals(1, h.errors);
         assertEquals(1, h.closes);
         Harness cancelled = new Harness();
@@ -224,6 +271,7 @@ public class ResponsesProtocolTest {
         assertTrue(cancelled.messages.isEmpty());
     }
 
+    /** 回调结束后恢复外层线程上下文，避免嵌套调用污染。 */
     @Test
     public void restoresCallingThreadContext() {
         ChatContext previous = new ChatContext();
@@ -233,15 +281,19 @@ public class ResponsesProtocolTest {
             h.start();
             h.send("response.completed", Maps.of("response", completed(message("done"))));
             assertSame(previous, ChatContextHolder.currentContext());
-        } finally { ChatContextHolder.clear(); }
+        } finally {
+            ChatContextHolder.clear();
+        }
     }
 
+    /** 禁止将服务端会话参数与本地历史回传混用。 */
     @Test(expected = IllegalArgumentException.class)
     public void rejectsUnsupportedServerConversation() {
-        builder.buildRequestBody(new SimplePrompt("hello"), ChatOptions.builder()
-            .addExtraBody("previous_response_id", "resp_1").build(), config);
+        builder.buildRequestBody(new SimplePrompt("hello"),
+            ChatOptions.builder().addExtraBody("previous_response_id", "resp_1").build(), config);
     }
 
+    /** 不支持的媒体输入必须显式报错，不能静默丢弃。 */
     @Test(expected = IllegalArgumentException.class)
     public void rejectsUnsupportedMediaInsteadOfDroppingIt() {
         SimplePrompt prompt = new SimplePrompt("describe");
@@ -249,6 +301,7 @@ public class ResponsesProtocolTest {
         builder.buildRequestBody(prompt, new ChatOptions(), config);
     }
 
+    /** 通过模型流式入口验证请求构建和完整的打开、消息、关闭回调。 */
     @Test
     public void streamingModelBuildsResponsesBodyAndCompletes() {
         config.setLogEnabled(false);
@@ -259,15 +312,23 @@ public class ResponsesProtocolTest {
             public StreamClient getStreamClient() {
                 return new StreamClient() {
                     StreamClientListener target;
-                    public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig cfg) {
+                    public void start(String url, Map<String, String> headers, String body,
+                        StreamClientListener listener, BaseChatConfig cfg) {
                         target = listener;
                         assertTrue(JSON.parseObject(body).getBooleanValue("stream"));
                         assertTrue(url.endsWith("/v1/responses"));
                         listener.onStart(this);
-                        listener.onMessage(this, Maps.of("type", "response.output_text.delta").set("delta", "hello").toJSON());
-                        listener.onMessage(this, Maps.of("type", "response.completed").set("response", completed(message("hello"))).toJSON());
+                        listener.onMessage(
+                            this, Maps.of("type", "response.output_text.delta").set("delta", "hello").toJSON());
+                        listener.onMessage(this,
+                            Maps.of("type", "response.completed")
+                                .set("response", completed(message("hello")))
+                                .toJSON());
                     }
-                    public void stop() { if (target != null) target.onStop(this); }
+                    public void stop() {
+                        if (target != null)
+                            target.onStop(this);
+                    }
                 };
             }
         });
@@ -275,10 +336,18 @@ public class ResponsesProtocolTest {
         final int[] closed = {0};
         final List<AiMessage> output = new ArrayList<>();
         model.chatStream("hello", new StreamResponseListener() {
-            public void onOpen(StreamContext ctx) { opened[0]++; }
-            public void onMessage(StreamContext ctx, AiMessageResponse response) { output.add(response.getMessage()); }
-            public void onError(StreamContext ctx, Throwable error) { throw new AssertionError(error); }
-            public void onClose(StreamContext ctx) { closed[0]++; }
+            public void onOpen(StreamContext ctx) {
+                opened[0]++;
+            }
+            public void onMessage(StreamContext ctx, AiMessageResponse response) {
+                output.add(response.getMessage());
+            }
+            public void onError(StreamContext ctx, Throwable error) {
+                throw new AssertionError(error);
+            }
+            public void onClose(StreamContext ctx) {
+                closed[0]++;
+            }
         });
         assertEquals(1, opened[0]);
         assertEquals(1, closed[0]);
@@ -288,6 +357,7 @@ public class ResponsesProtocolTest {
         assertNull(ChatContextHolder.currentContext());
     }
 
+    /** 业务在 onOpen 中取消时，不应继续发起网络请求。 */
     @Test
     public void cancellationDuringOpenDoesNotStartNetworkRequest() {
         config.setLogEnabled(false);
@@ -297,37 +367,52 @@ public class ResponsesProtocolTest {
             @Override
             public StreamClient getStreamClient() {
                 return new StreamClient() {
-                    public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig cfg) {
+                    public void start(String url, Map<String, String> headers, String body,
+                        StreamClientListener listener, BaseChatConfig cfg) {
                         fail("Cancelled stream must not start transport");
                     }
-                    public void stop() { }
+                    public void stop() {
+                    }
                 };
             }
         });
         final int[] closed = {0};
         model.chatStream("hello", new StreamResponseListener() {
-            public void onOpen(StreamContext ctx) { ctx.getClient().stop(); }
-            public void onMessage(StreamContext ctx, AiMessageResponse response) { fail("Unexpected response"); }
-            public void onError(StreamContext ctx, Throwable error) { throw new AssertionError(error); }
-            public void onClose(StreamContext ctx) { closed[0]++; }
+            public void onOpen(StreamContext ctx) {
+                ctx.getClient().stop();
+            }
+            public void onMessage(StreamContext ctx, AiMessageResponse response) {
+                fail("Unexpected response");
+            }
+            public void onError(StreamContext ctx, Throwable error) {
+                throw new AssertionError(error);
+            }
+            public void onClose(StreamContext ctx) {
+                closed[0]++;
+            }
         });
         assertEquals(1, closed[0]);
     }
 
+    /** 空响应、非法 JSON 及服务端错误统一转换为错误响应。 */
     @Test
     public void malformedAndEmptyHttpBodiesBecomeErrorResponses() {
         config.setLogEnabled(false);
         config.setObservabilityEnabled(false);
         config.setRetryEnabled(false);
         OpenAIResponsesChatModel model = config.toChatModel();
-        for (String raw : Arrays.asList("", "not json", "null", "{\"error\":{\"message\":\"bad request\",\"code\":\"invalid_request_error\"}}")) {
+        for (String raw : Arrays.asList("", "not json", "null",
+                 "{\"error\":{\"message\":\"bad request\",\"code\":\"invalid_request_error\"}}")) {
             ((ResponsesChatClient) model.getChatClient()).setHttpClient(new AgentsFlexHttpClient() {
-                public String post(String url, Map<String, String> headers, String payload) { return raw; }
+                public String post(String url, Map<String, String> headers, String payload) {
+                    return raw;
+                }
             });
             assertTrue(model.chat(new SimplePrompt("hello")).isError());
         }
     }
 
+    /** 流式未完成响应保留部分正文和结束原因，不下发工具调用。 */
     @Test
     public void streamedIncompleteKeepsTextButNotToolCalls() {
         Harness h = new Harness();
@@ -341,7 +426,9 @@ public class ResponsesProtocolTest {
         assertEquals("partial", h.messages.get(0).getMessage().getFullContent());
         assertEquals(1, h.closes);
     }
+    /** 模拟可重入的传输关闭回调，并记录业务监听器收到的事件。 */
     private static class Harness implements StreamResponseListener {
+
         final ChatContext chat = new ChatContext();
         final List<AiMessageResponse> messages = new ArrayList<>();
         int closes;
@@ -349,15 +436,35 @@ public class ResponsesProtocolTest {
         boolean stopped;
         StreamContext streamContext;
         final StreamClient transport = new StreamClient() {
-            public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig config) { }
-            public void stop() { stopped = true; bridge.onStop(this); }
+            public void start(String url, Map<String, String> headers, String body, StreamClientListener listener,
+                BaseChatConfig config) {
+            }
+            public void stop() {
+                stopped = true;
+                bridge.onStop(this);
+            }
         };
         final ResponsesStreamListener bridge = new ResponsesStreamListener(null, chat, transport, this);
-        void start() { bridge.onStart(transport); }
-        void send(String type, Maps fields) { fields.set("type", type); bridge.onMessage(transport, fields.toJSON()); }
-        public void onOpen(StreamContext context) { streamContext = context; assertSame(chat, ChatContextHolder.currentContext()); }
-        public void onMessage(StreamContext context, AiMessageResponse response) { messages.add(response); assertSame(chat, ChatContextHolder.currentContext()); }
-        public void onError(StreamContext context, Throwable error) { errors++; }
-        public void onClose(StreamContext context) { closes++; }
+        void start() {
+            bridge.onStart(transport);
+        }
+        void send(String type, Maps fields) {
+            fields.set("type", type);
+            bridge.onMessage(transport, fields.toJSON());
+        }
+        public void onOpen(StreamContext context) {
+            streamContext = context;
+            assertSame(chat, ChatContextHolder.currentContext());
+        }
+        public void onMessage(StreamContext context, AiMessageResponse response) {
+            messages.add(response);
+            assertSame(chat, ChatContextHolder.currentContext());
+        }
+        public void onError(StreamContext context, Throwable error) {
+            errors++;
+        }
+        public void onClose(StreamContext context) {
+            closes++;
+        }
     }
 }

--- a/agents-flex-chat/agents-flex-chat-openai/src/test/java/com/agentsflex/model/chat/openai/responses/ResponsesProtocolTest.java
+++ b/agents-flex-chat/agents-flex-chat-openai/src/test/java/com/agentsflex/model/chat/openai/responses/ResponsesProtocolTest.java
@@ -1,0 +1,363 @@
+/*
+ *  Copyright (c) 2023-2026, Agents-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.agentsflex.model.chat.openai.responses;
+
+import com.agentsflex.core.message.*;
+import com.agentsflex.core.model.chat.*;
+import com.agentsflex.core.model.chat.response.AiMessageResponse;
+import com.agentsflex.core.model.chat.tool.Tool;
+import com.agentsflex.core.model.chat.tool.Parameter;
+import com.agentsflex.core.model.client.*;
+import com.agentsflex.core.prompt.*;
+import com.agentsflex.core.util.Maps;
+import com.alibaba.fastjson2.*;
+import org.junit.Test;
+import java.util.*;
+import static org.junit.Assert.*;
+
+public class ResponsesProtocolTest {
+    private final OpenAIResponsesChatConfig config = new OpenAIResponsesChatConfig();
+    private final ResponsesRequestSpecBuilder builder = new ResponsesRequestSpecBuilder();
+    private final ResponsesResponseParser parser = new ResponsesResponseParser();
+
+    private static JSONObject completed(Object... output) {
+        return JSON.parseObject(JSON.toJSONString(Maps.of("id", "resp_1").set("object", "response")
+            .set("status", "completed").set("model", "test-model").set("created_at", 123)
+            .set("output", Arrays.asList(output))));
+    }
+
+    private static Object message(String text) {
+        return Maps.of("type", "message").set("role", "assistant").set("content",
+            Collections.singletonList(Maps.of("type", "output_text").set("text", text)));
+    }
+
+    private static Object call(String id, String args) {
+        return Maps.of("type", "function_call").set("id", "item_" + id).set("call_id", id)
+            .set("name", "weather").set("arguments", args);
+    }
+
+    @Test
+    public void mapsRequestAndDoesNotSendChatCompletionFields() {
+        config.setApiKey("test-key");
+        ChatOptions options = ChatOptions.builder().maxTokens(100).responseFormatToJsonObject().build();
+        SimplePrompt prompt = new SimplePrompt("hello");
+        JSONObject body = JSON.parseObject(builder.buildRequestBody(prompt, options, config, true));
+        assertEquals("user", body.getJSONArray("input").getJSONObject(0).getString("role"));
+        assertEquals(100, body.getIntValue("max_output_tokens"));
+        assertTrue(body.getBooleanValue("stream"));
+        assertFalse(body.getBooleanValue("store"));
+        assertEquals("json_object", body.getJSONObject("text").getJSONObject("format").getString("type"));
+        for (String key : Arrays.asList("messages", "max_tokens", "response_format", "stream_options")) assertFalse(body.containsKey(key));
+        ChatRequestSpec spec = builder.buildRequestSpec(prompt, options, config);
+        assertEquals("https://api.openai.com/v1/responses", spec.getUrl());
+        assertEquals("Bearer test-key", spec.getHeaders().get("Authorization"));
+        assertFalse(JSON.parseObject(builder.buildRequestBody(prompt, options, config)).containsKey("stream"));
+    }
+
+    @Test
+    public void flattensJsonSchemaWithoutMutatingOptions() {
+        Map<String, Object> schema = Maps.of("name", "answer").set("strict", true)
+            .set("schema", Maps.of("type", "object"));
+        ChatOptions options = ChatOptions.builder().responseFormatToJsonSchema(schema).build();
+        JSONObject body = JSON.parseObject(builder.buildRequestBody(new SimplePrompt("hello"), options, config));
+        JSONObject format = body.getJSONObject("text").getJSONObject("format");
+        assertEquals("answer", format.getString("name"));
+        assertEquals("json_schema", format.getString("type"));
+        assertFalse(format.containsKey("json_schema"));
+        assertTrue(options.getResponseFormat().containsKey("json_schema"));
+    }
+
+    @Test
+    public void roundTripsFunctionCallsAndEncryptedReasoningThroughCopiedHistory() {
+        Object reasoning = Maps.of("type", "reasoning").set("id", "rs_1")
+            .set("encrypted_content", "opaque").set("summary", Collections.emptyList());
+        AiMessage ai = parser.parse(completed(reasoning, call("call_a", "{}"), call("call_b", "{}")).toJSONString(), null).getMessage();
+        assertEquals("call_a", ai.getToolCalls().get(0).getId());
+        assertEquals(2, ai.getToolCalls().size());
+        SimplePrompt initial = new SimplePrompt("weather?");
+        initial.addTool(new Tool() {
+            public String getName() { return "weather"; }
+            public String getDescription() { return "Weather"; }
+            public Parameter[] getParameters() { return new Parameter[0]; }
+            public Object invoke(Map<String, Object> args) { return "sunny"; }
+        });
+        initial.setToolChoice("required");
+        ChatContext context = new ChatContext();
+        context.setPrompt(initial);
+        List<ToolMessage> results = new AiMessageResponse(context, "", ai).executeToolCallsAndGetToolMessages();
+        assertEquals("call_b", results.get(1).getToolCallId());
+        List<Message> history = new ArrayList<>(initial.getMessages());
+        history.add(ai.copy());
+        history.addAll(results);
+        Prompt next = new Prompt() { public List<Message> getMessages() { return history; } };
+        next.addTools(initial.getTools());
+        JSONObject body = JSON.parseObject(builder.buildRequestBody(next, new ChatOptions(), config));
+        JSONArray input = body.getJSONArray("input");
+        assertEquals("opaque", input.getJSONObject(1).getString("encrypted_content"));
+        assertEquals("function_call", input.getJSONObject(2).getString("type"));
+        assertEquals("call_a", input.getJSONObject(4).getString("call_id"));
+        assertEquals("sunny", input.getJSONObject(4).getString("output"));
+        JSONObject tool = body.getJSONArray("tools").getJSONObject(0);
+        assertEquals("weather", tool.getString("name"));
+        assertFalse(tool.containsKey("function"));
+        assertFalse(tool.getBooleanValue("strict"));
+    }
+
+    @Test
+    public void parsesAllTextPartsUsageAndRefusal() {
+        JSONObject response = completed(message("hello"), message(" world"));
+        response.put("usage", Maps.of("input_tokens", 10).set("output_tokens", 3).set("total_tokens", 13)
+            .set("input_tokens_details", Maps.of("cached_tokens", 2)));
+        AiMessage ai = parser.parse(response.toJSONString(), null).getMessage();
+        assertEquals("hello world", ai.getContent());
+        assertEquals(Integer.valueOf(13), ai.getTotalTokens());
+        assertEquals(2, ai.getPromptTokensDetails().get("cached_tokens"));
+        assertEquals("resp_1", ai.getId());
+        JSONObject refused = completed(Maps.of("type", "message").set("content",
+            Collections.singletonList(Maps.of("type", "refusal").set("refusal", "declined"))));
+        assertEquals("declined", parser.parse(refused.toJSONString(), null).getMessage().getRefusal());
+    }
+
+    @Test
+    public void incompleteResponseDoesNotExecutePartialTools() {
+        JSONObject response = completed(message("partial"), call("call_a", "{"));
+        response.put("status", "incomplete");
+        response.put("incomplete_details", Maps.of("reason", "max_output_tokens"));
+        AiMessageResponse parsed = parser.parse(response.toJSONString(), null);
+        assertFalse(parsed.hasToolCalls());
+        assertEquals("length", parsed.getMessage().getFinishReason());
+        assertEquals("partial", parsed.getMessage().getContent());
+    }
+
+    @Test
+    public void returnsStructuredErrorsAndRejectsUnsupportedOutputs() {
+        AiMessageResponse error = parser.parse("{\"status\":\"failed\",\"error\":{\"message\":\"failed\",\"code\":\"server_error\"}}", null);
+        assertTrue(error.isError());
+        assertEquals("server_error", error.getErrorCode());
+        assertTrue(parser.parse(completed(Maps.of("type", "web_search_call")).toJSONString(), null).isError());
+        assertTrue(parser.parse("{\"status\":\"queued\"}", null).isError());
+    }
+
+    @Test
+    public void modelUsesResponsesClientEndToEnd() {
+        config.setApiKey("test-key");
+        config.setLogEnabled(false);
+        config.setObservabilityEnabled(false);
+        config.setRetryEnabled(false);
+        OpenAIResponsesChatModel model = config.toChatModel();
+        ((ResponsesChatClient) model.getChatClient()).setHttpClient(new AgentsFlexHttpClient() {
+            @Override
+            public String post(String url, Map<String, String> headers, String payload) {
+                assertTrue(url.endsWith("/v1/responses"));
+                assertEquals("hello", JSON.parseObject(payload).getJSONArray("input").getJSONObject(0).getString("content"));
+                return completed(message("answer")).toJSONString();
+            }
+        });
+        assertEquals("answer", model.chat("hello"));
+        assertNull(ChatContextHolder.currentContext());
+    }
+
+    @Test
+    public void streamsTextOnceAndPublishesCompleteParallelCallsAtTerminalEvent() {
+        Harness h = new Harness();
+        h.start();
+        h.send("response.output_text.delta", Maps.of("delta", "Hi"));
+        h.send("response.function_call_arguments.delta", Maps.of("item_id", "item_a").set("delta", "{"));
+        h.send("response.function_call_arguments.delta", Maps.of("item_id", "item_b").set("delta", "{"));
+        assertEquals(1, h.messages.size());
+        h.send("response.completed", Maps.of("response", completed(message("Hi"), call("a", "{}"), call("b", "{}"))));
+        h.send("response.completed", Maps.of("response", completed(message("Hi"))));
+        h.bridge.onStop(h.transport);
+        assertEquals(2, h.messages.size());
+        AiMessage last = h.messages.get(1).getMessage();
+        assertEquals("", last.getContent());
+        assertEquals("Hi", last.getFullContent());
+        assertEquals(2, last.getToolCalls().size());
+        assertEquals("b", last.getToolCalls().get(1).getId());
+        assertEquals(1, h.closes);
+        assertEquals(0, h.errors);
+        assertTrue(h.stopped);
+    }
+
+    @Test
+    public void prematureEofAndMalformedEventsFailWithoutFinishedMessage() {
+        Harness h = new Harness();
+        h.start();
+        h.bridge.onStop(h.transport);
+        h.bridge.onStop(h.transport);
+        assertEquals(1, h.errors);
+        assertEquals(1, h.closes);
+        assertTrue(h.messages.isEmpty());
+        Harness malformed = new Harness();
+        malformed.start();
+        malformed.bridge.onMessage(malformed.transport, "not json");
+        assertEquals(1, malformed.errors);
+        assertEquals(1, malformed.closes);
+    }
+
+    @Test
+    public void failedEventAndExplicitCancellationCloseExactlyOnce() {
+        Harness h = new Harness();
+        h.start();
+        h.send("response.failed", Maps.of("response", Maps.of("status", "failed").set("error", Maps.of("message", "failure"))));
+        assertEquals(1, h.errors);
+        assertEquals(1, h.closes);
+        Harness cancelled = new Harness();
+        cancelled.start();
+        cancelled.streamContext.getClient().stop();
+        cancelled.bridge.onFailure(cancelled.transport, new RuntimeException("cancelled"));
+        assertEquals(0, cancelled.errors);
+        assertEquals(1, cancelled.closes);
+        assertTrue(cancelled.messages.isEmpty());
+    }
+
+    @Test
+    public void restoresCallingThreadContext() {
+        ChatContext previous = new ChatContext();
+        ChatContextHolder.set(previous);
+        try {
+            Harness h = new Harness();
+            h.start();
+            h.send("response.completed", Maps.of("response", completed(message("done"))));
+            assertSame(previous, ChatContextHolder.currentContext());
+        } finally { ChatContextHolder.clear(); }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnsupportedServerConversation() {
+        builder.buildRequestBody(new SimplePrompt("hello"), ChatOptions.builder()
+            .addExtraBody("previous_response_id", "resp_1").build(), config);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnsupportedMediaInsteadOfDroppingIt() {
+        SimplePrompt prompt = new SimplePrompt("describe");
+        prompt.addImageUrl("https://example.com/image.png");
+        builder.buildRequestBody(prompt, new ChatOptions(), config);
+    }
+
+    @Test
+    public void streamingModelBuildsResponsesBodyAndCompletes() {
+        config.setLogEnabled(false);
+        config.setObservabilityEnabled(false);
+        OpenAIResponsesChatModel model = config.toChatModel();
+        model.setChatClient(new ResponsesChatClient(model) {
+            @Override
+            public StreamClient getStreamClient() {
+                return new StreamClient() {
+                    StreamClientListener target;
+                    public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig cfg) {
+                        target = listener;
+                        assertTrue(JSON.parseObject(body).getBooleanValue("stream"));
+                        assertTrue(url.endsWith("/v1/responses"));
+                        listener.onStart(this);
+                        listener.onMessage(this, Maps.of("type", "response.output_text.delta").set("delta", "hello").toJSON());
+                        listener.onMessage(this, Maps.of("type", "response.completed").set("response", completed(message("hello"))).toJSON());
+                    }
+                    public void stop() { if (target != null) target.onStop(this); }
+                };
+            }
+        });
+        final int[] opened = {0};
+        final int[] closed = {0};
+        final List<AiMessage> output = new ArrayList<>();
+        model.chatStream("hello", new StreamResponseListener() {
+            public void onOpen(StreamContext ctx) { opened[0]++; }
+            public void onMessage(StreamContext ctx, AiMessageResponse response) { output.add(response.getMessage()); }
+            public void onError(StreamContext ctx, Throwable error) { throw new AssertionError(error); }
+            public void onClose(StreamContext ctx) { closed[0]++; }
+        });
+        assertEquals(1, opened[0]);
+        assertEquals(1, closed[0]);
+        assertEquals(2, output.size());
+        assertEquals("hello", output.get(1).getFullContent());
+        assertTrue(output.get(1).isFinalDelta());
+        assertNull(ChatContextHolder.currentContext());
+    }
+
+    @Test
+    public void cancellationDuringOpenDoesNotStartNetworkRequest() {
+        config.setLogEnabled(false);
+        config.setObservabilityEnabled(false);
+        OpenAIResponsesChatModel model = config.toChatModel();
+        model.setChatClient(new ResponsesChatClient(model) {
+            @Override
+            public StreamClient getStreamClient() {
+                return new StreamClient() {
+                    public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig cfg) {
+                        fail("Cancelled stream must not start transport");
+                    }
+                    public void stop() { }
+                };
+            }
+        });
+        final int[] closed = {0};
+        model.chatStream("hello", new StreamResponseListener() {
+            public void onOpen(StreamContext ctx) { ctx.getClient().stop(); }
+            public void onMessage(StreamContext ctx, AiMessageResponse response) { fail("Unexpected response"); }
+            public void onError(StreamContext ctx, Throwable error) { throw new AssertionError(error); }
+            public void onClose(StreamContext ctx) { closed[0]++; }
+        });
+        assertEquals(1, closed[0]);
+    }
+
+    @Test
+    public void malformedAndEmptyHttpBodiesBecomeErrorResponses() {
+        config.setLogEnabled(false);
+        config.setObservabilityEnabled(false);
+        config.setRetryEnabled(false);
+        OpenAIResponsesChatModel model = config.toChatModel();
+        for (String raw : Arrays.asList("", "not json", "null", "{\"error\":{\"message\":\"bad request\",\"code\":\"invalid_request_error\"}}")) {
+            ((ResponsesChatClient) model.getChatClient()).setHttpClient(new AgentsFlexHttpClient() {
+                public String post(String url, Map<String, String> headers, String payload) { return raw; }
+            });
+            assertTrue(model.chat(new SimplePrompt("hello")).isError());
+        }
+    }
+
+    @Test
+    public void streamedIncompleteKeepsTextButNotToolCalls() {
+        Harness h = new Harness();
+        h.start();
+        JSONObject response = completed(message("partial"), call("a", "{"));
+        response.put("status", "incomplete");
+        response.put("incomplete_details", Maps.of("reason", "max_output_tokens"));
+        h.send("response.incomplete", Maps.of("response", response));
+        assertEquals("length", h.messages.get(0).getMessage().getFinishReason());
+        assertFalse(h.messages.get(0).hasToolCalls());
+        assertEquals("partial", h.messages.get(0).getMessage().getFullContent());
+        assertEquals(1, h.closes);
+    }
+    private static class Harness implements StreamResponseListener {
+        final ChatContext chat = new ChatContext();
+        final List<AiMessageResponse> messages = new ArrayList<>();
+        int closes;
+        int errors;
+        boolean stopped;
+        StreamContext streamContext;
+        final StreamClient transport = new StreamClient() {
+            public void start(String url, Map<String, String> headers, String body, StreamClientListener listener, BaseChatConfig config) { }
+            public void stop() { stopped = true; bridge.onStop(this); }
+        };
+        final ResponsesStreamListener bridge = new ResponsesStreamListener(null, chat, transport, this);
+        void start() { bridge.onStart(transport); }
+        void send(String type, Maps fields) { fields.set("type", type); bridge.onMessage(transport, fields.toJSON()); }
+        public void onOpen(StreamContext context) { streamContext = context; assertSame(chat, ChatContextHolder.currentContext()); }
+        public void onMessage(StreamContext context, AiMessageResponse response) { messages.add(response); assertSame(chat, ChatContextHolder.currentContext()); }
+        public void onError(StreamContext context, Throwable error) { errors++; }
+        public void onClose(StreamContext context) { closes++; }
+    }
+}

--- a/docs/zh/chat/getting-started.md
+++ b/docs/zh/chat/getting-started.md
@@ -29,6 +29,10 @@ Agents-Flex 用统一的 `ChatModel` 接口连接 OpenAI、DeepSeek、Qwen 以�
 客服、知识助手和 Tool Calling Agent 需要使用 `Prompt` 保存多条消息，并在每轮把模型回复和工具结果加入后续
 请求。需要跨请求保存历史时，再配合 `MemoryPrompt`。
 
+### OpenAI Responses
+
+使用 `/v1/responses` 时，选择独立的 [OpenAI Responses 适配器](./openai-responses.md)，支持文本、流式输出和本地工具调用。
+
 ### OpenAI 兼容服务迁移
 
 自建网关或第三方服务实现 Chat Completions 协议时，可以复用 `OpenAIChatConfig`，覆盖 `endpoint`、

--- a/docs/zh/chat/openai-responses.md
+++ b/docs/zh/chat/openai-responses.md
@@ -1,0 +1,62 @@
+---
+title: OpenAI Responses
+description: 使用 Responses API 进行文本对话、流式输出和本地工具调用。
+---
+
+# OpenAI Responses
+
+`agents-flex-chat-openai` 提供独立的 `OpenAIResponsesChatModel`，使用 `/v1/responses`。
+现有 `OpenAIChatModel` 继续使用 Chat Completions；两者共享 `ChatModel` 接口。
+
+## 创建模型
+
+```java
+import com.agentsflex.core.model.chat.ChatModel;
+import com.agentsflex.model.chat.openai.responses.OpenAIResponsesChatConfig;
+
+OpenAIResponsesChatConfig config = new OpenAIResponsesChatConfig();
+config.setApiKey(System.getenv("OPENAI_API_KEY"));
+config.setModel("gpt-4.1");
+ChatModel model = config.toChatModel();
+String answer = model.chat("用一句话解释依赖注入。");
+```
+
+可以通过 `setEndpoint`、`setRequestPath` 接入实现 Responses 协议的服务。
+无需添加新的依赖。支持实例级拦截器的构造方法为
+`new OpenAIResponsesChatModel(config, interceptors)`。
+
+## 参数与输出
+
+- `ChatOptions.maxTokens` 映射为 `max_output_tokens`。
+- `responseFormatToJsonObject()` 和 `responseFormatToJsonSchema(...)` 映射为 `text.format`。
+- 模型特有参数（如 `reasoning`）通过 `extraBody` 传递；是否支持温度等参数取决于所选模型。
+- 使用相同的 `chatStream(...)` 和 `StreamResponseListener` 接收正文或推理摘要增量。
+- 最后一条消息的 `finished` 为 `true`，完整正文从 `getFullContent()` 读取。
+- 输入、输出 Token 及其明细映射为 `AiMessage` 的对应统计字段。
+- `incomplete` 响应保留已有正文；达到输出上限时 `finishReason` 为 `length`，不暴露未完成的工具调用。
+- 服务端失败和未收到终止事件的断流进入错误路径；用户主动停止只关闭流，不伪造成功响应。
+
+## 本地工具和历史消息
+
+工具仍由 Agents-Flex 执行。请求构建器把函数定义转换成 Responses 格式，显式使用 `strict: false`
+保留现有可选参数的语义；`ToolMessage.toolCallId` 映射为 `function_call_output.call_id`。
+流式工具调用在终止响应中一次性提供完整参数，避免把交错的参数分片混合或提前执行。
+
+该适配器默认发送 `store: false`，由调用方通过 `Prompt` / `MemoryPrompt` 提供历史。
+同时请求 `reasoning.encrypted_content`，把推理项存入 `AiMessage` 的
+`openai.responses.reasoning_items` 元数据，并在下一次请求中回传。
+使用推理模型时，请保留返回的消息及其元数据（包括自定义历史存储），不要只保存正文或推理摘要。
+框架的 `AiMessage.copy()` 会保留该元数据。
+
+## 当前范围
+
+支持文本输入、同步与 SSE 对话、JSON 输出、本地函数工具及本地历史回传。
+图片/音频/视频/文件输入、服务端会话（`previous_response_id` / `conversation`）、后台任务及托管工具
+不在此适配器的支持范围内。媒体输入与服务端会话参数会被明确拒绝；不要用 `extraBody` 绕过这些限制。
+`stop` 序列不属于 Responses 请求参数，会在构建请求时被拒绝。
+Responses 的专有能力和 Chat Completions 参数不能直接互换。
+
+验证使用离线协议样例和模拟传输，不需要 API Key；真实服务仍需使用自己的凭证进行联调。
+
+协议参考：[迁移指南](https://developers.openai.com/api/docs/guides/migrate-to-responses)、
+[流式事件](https://platform.openai.com/docs/api-reference/responses-streaming)。


### PR DESCRIPTION
Adds an opt-in `OpenAIResponsesChatModel` in the existing OpenAI module so applications can call `/v1/responses` through `ChatModel`. The existing Chat Completions adapter is unchanged.

- Maps text history, local function definitions/results, output limits and JSON output formats to the Responses protocol.
- Parses text, refusal, usage and terminal status; preserves encrypted reasoning items in message metadata for local history replay with `store: false`.
- Supports SSE text/reasoning-summary deltas, terminal snapshots, cancellation and premature-EOF errors. Function calls are emitted with complete arguments at completion; incomplete responses do not expose partial calls for execution.
- Adds Chinese usage documentation and 17 offline protocol tests, including model/client wiring, two-call tool-result replay, copied reasoning metadata, duplicate terminal events, cancellation during opening, malformed responses and interrupted streams.

### Scope

This initial adapter supports text and local function tools. Multimodal input, provider-hosted tools, server-side conversations and background tasks are outside its scope. It does not require a new dependency or change the Agent runtime. Live-provider validation has not been performed.

### Validation

49 tests passed (17 new protocol tests plus 32 existing configuration, parser, memory, interceptor and router tests), using JDK 26 with the repository's Java 8 source/target settings:

```sh
mvn -pl agents-flex-chat/agents-flex-chat-openai -am test \
  -Dtest=ResponsesProtocolTest,OpenAIChatConfigTest,ChatInterceptorRequestPreparationTest,DefaultAiMessageParserTest,ChatMemoryMessageContractTest,RoutedChatModelTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

`git diff --check` passed. Tests use synthetic protocol fixtures and stub transports; no API credentials are required.

Protocol reference: https://developers.openai.com/api/docs/guides/migrate-to-responses

AI-assisted implementation, inspected and tested before submission.
