### PR TITLE
fix(core): 修复 Markdown 标题切分器误识别代码围栏

### DIFF
--- a/agents-flex-core/src/main/java/com/agentsflex/core/document/splitter/MarkdownHeaderSplitter.java
+++ b/agents-flex-core/src/main/java/com/agentsflex/core/document/splitter/MarkdownHeaderSplitter.java
@@ -84,7 +84,8 @@ public class MarkdownHeaderSplitter implements DocumentSplitter {
         StringBuilder currentContent = new StringBuilder();
         int currentStartLine = 0;
 
-        boolean inCodeBlock = false;
+        char fenceMarker = 0;
+        int fenceLength = 0;
 
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i];
@@ -93,15 +94,23 @@ public class MarkdownHeaderSplitter implements DocumentSplitter {
                 continue;
             }
 
-            // 检测围栏代码块的开始或结束（支持 ``` 或 ~~~）
+            // 结束围栏必须使用相同字符，长度不短于开启围栏，且后面只能有空白。
             String trimmedLine = stripLeading(line);
-            if (trimmedLine.startsWith("```") || trimmedLine.startsWith("~~~")) {
-                inCodeBlock = !inCodeBlock;
+            int currentFenceLength = fenceRunLength(trimmedLine);
+            if (currentFenceLength >= 3) {
+                if (fenceMarker == 0) {
+                    fenceMarker = trimmedLine.charAt(0);
+                    fenceLength = currentFenceLength;
+                } else if (trimmedLine.charAt(0) == fenceMarker && currentFenceLength >= fenceLength
+                    && trimmedLine.substring(currentFenceLength).trim().isEmpty()) {
+                    fenceMarker = 0;
+                    fenceLength = 0;
+                }
                 currentContent.append(line).append("\n");
                 continue;
             }
 
-            if (!inCodeBlock) {
+            if (fenceMarker == 0) {
                 HeaderInfo header = parseHeader(line);
                 if (header != null && header.level <= splitLevel) {
                     // 触发新 chunk
@@ -203,6 +212,18 @@ public class MarkdownHeaderSplitter implements DocumentSplitter {
 
         String text = line.substring(i).trim();
         return new HeaderInfo(level, text);
+    }
+
+    private static int fenceRunLength(String line) {
+        if (line.isEmpty() || (line.charAt(0) != '`' && line.charAt(0) != '~')) {
+            return 0;
+        }
+        char marker = line.charAt(0);
+        int length = 1;
+        while (length < line.length() && line.charAt(length) == marker) {
+            length++;
+        }
+        return length;
     }
 
     private static String stripLeading(String s) {

--- a/agents-flex-core/src/test/java/com/agentsflex/core/test/splitter/MarkdownHeaderSplitterTest.java
+++ b/agents-flex-core/src/test/java/com/agentsflex/core/test/splitter/MarkdownHeaderSplitterTest.java
@@ -2,10 +2,67 @@ package com.agentsflex.core.test.splitter;
 
 import com.agentsflex.core.document.Document;
 import com.agentsflex.core.document.splitter.MarkdownHeaderSplitter;
+import org.junit.Test;
 
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+
 public class MarkdownHeaderSplitterTest {
+
+    @Test
+    public void shouldKeepShorterFencesInsideCodeBlock() {
+        assertFencedSection("````markdown", "```\n# Example heading\n```", "````");
+        assertFencedSection("~~~~markdown", "~~~\n# Example heading\n~~~", "~~~~");
+    }
+
+    @Test
+    public void shouldNotCloseCodeBlockWithDifferentMarker() {
+        assertFencedSection("```markdown", "~~~\n# Example heading\n~~~", "```");
+        assertFencedSection("~~~markdown", "```\n# Example heading\n```", "~~~");
+    }
+
+    @Test
+    public void shouldNotCloseCodeBlockWithTrailingText() {
+        assertFencedSection("```", "```not-a-closing-fence\n# Example heading", "```");
+        assertFencedSection("~~~", "~~~not-a-closing-fence\n# Example heading", "~~~");
+    }
+
+    @Test
+    public void shouldResumeSplittingAfterMatchingOrLongerFence() {
+        assertFencedSection("```markdown", "# Example heading", "```  \t");
+        assertFencedSection("~~~markdown", "# Example heading", "~~~  \t");
+        assertFencedSection("```markdown", "# Example heading", "````");
+        assertFencedSection("~~~markdown", "# Example heading", "~~~~");
+    }
+
+    @Test
+    public void shouldKeepUnclosedCodeBlockThroughEndOfDocument() {
+        String markdown = "# Examples\n````markdown\n```\n# Example heading";
+
+        List<Document> chunks = new MarkdownHeaderSplitter(1).split(Document.of(markdown));
+
+        assertEquals(1, chunks.size());
+        assertEquals(markdown, chunks.get(0).getContent());
+        assertEquals("Examples", chunks.get(0).getMetadata("header_path"));
+    }
+
+    private void assertFencedSection(String opening, String body, String closing) {
+        String firstSection = "# Examples\n" + opening + "\n" + body + "\n" + closing;
+        String secondSection = "# Next\nText";
+        String markdown = firstSection + "\n" + secondSection;
+
+        List<Document> chunks = new MarkdownHeaderSplitter(1).split(Document.of(markdown));
+
+        assertEquals(2, chunks.size());
+        assertEquals(firstSection.trim(), chunks.get(0).getContent());
+        assertEquals(secondSection, chunks.get(1).getContent());
+        assertEquals("Examples", chunks.get(0).getMetadata("header_path"));
+        assertEquals("Next", chunks.get(1).getMetadata("header_path"));
+        assertEquals("0", chunks.get(0).getMetadata("start_line"));
+        assertEquals(String.valueOf(firstSection.split("\n").length - 1), chunks.get(0).getMetadata("end_line"));
+        assertEquals(String.valueOf(firstSection.split("\n").length), chunks.get(1).getMetadata("start_line"));
+    }
 
     public static void main(String[] args) {
 


### PR DESCRIPTION
`MarkdownHeaderSplitter` 遇到四反引号代码块内的三反引号、不同字符的围栏或带尾随文本的围栏时，会提前退出代码块，导致示例中的标题被误拆成文档片段，后续真实章节也可能被合并到错误的片段中。

本次记录开启围栏的字符和长度，仅在结束围栏使用相同字符、长度不短于开启围栏且后面没有非空白文本时关闭代码块。补充 5 个离线回归测试，覆盖反引号/波浪号、有效结束围栏、未闭合代码块，并检查片段正文、标题路径和行号。改动不增加依赖或公开 API。

验证（JDK 26，项目 Java 8 source/target）：

```sh
mvn -o -s F:/resume/work/agents-flex-settings.xml -pl agents-flex-core -Dtest=MarkdownHeaderSplitterTest,MarkdownTableSplitterTest,DocumentSplitterMetadataTest test
git diff --check
```

上述 Maven settings 仅将依赖缓存放到工作区并配置 Maven Central。16 个测试全部通过；修复前新增测试中有 4 个失败。测试不调用模型服务，也不需要 API Key。

围栏关闭规则参考：[CommonMark 0.31.2 §4.5](https://spec.commonmark.org/0.31.2/#fenced-code-blocks)。

本次使用 AI 辅助实现，已审查差异并完成上述验证。
